### PR TITLE
#66: Add ZEND_ASYNC_SCHEDULER_LAUNCH() to TrueAsync public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.0] - 2025-10-31
 
+### Added
+- **TrueAsync API**: Added `ZEND_ASYNC_SCHEDULER_LAUNCH()` macro for scheduler initialization
+
 ### Changed
 - **Deadlock Detection**: Replaced warnings with structured exception handling
   - Deadlock detection now throws `Async\DeadlockError` exception instead of multiple warnings
-  - **Breaking Change**: Applications relying on deadlock warnings 
+  - **Breaking Change**: Applications relying on deadlock warnings
   will need to be updated to catch `Async\DeadlockError` exceptions
 
 ## [0.4.0] - 2025-09-30

--- a/async_API.c
+++ b/async_API.c
@@ -1124,6 +1124,7 @@ void async_api_register(void)
 {
 	zend_async_scheduler_register(PHP_ASYNC_NAME_VERSION,
 								  false,
+								  async_scheduler_launch,
 								  async_new_coroutine,
 								  async_new_scope,
 								  (zend_async_new_context_t) async_context_new,

--- a/scheduler.c
+++ b/scheduler.c
@@ -747,7 +747,7 @@ bool async_scheduler_launch(void)
 		return false;
 	}
 
-	if (EG(active_fiber)) {
+	if (UNEXPECTED(EG(active_fiber))) {
 		async_throw_error("The True Async Scheduler cannot be started from within a Fiber");
 		return false;
 	}


### PR DESCRIPTION
       Expose async_scheduler_launch() function through the TrueAsync API to allow
       extensions to explicitly initialize and start the scheduler before creating
       coroutines. This is particularly useful for extensions that need deterministic
       scheduler initialization timing.

       Changes:
       - Add zend_async_scheduler_launch_t function pointer type
       - Add ZEND_ASYNC_SCHEDULER_LAUNCH() macro for scheduler initialization
       - Register scheduler_launch_fn as first parameter in zend_async_scheduler_register()
       - Update CHANGELOG.md with API addition in version 0.5.0