### PR TITLE
11-thread-pool: Implement thread pool API using libuv uv_queue_work

### DIFF
--- a/libuv_reactor.h
+++ b/libuv_reactor.h
@@ -116,6 +116,11 @@ struct _async_trigger_event_t
 	uv_async_t uv_handle;
 };
 
+typedef struct _libuv_work_wrapper_s {
+	uv_work_t uv_req;
+	zend_async_task_t *task;
+} libuv_work_wrapper_t;
+
 struct _async_io_t
 {
 	zend_async_io_t base;


### PR DESCRIPTION
Add libuv-backed implementation of zend_async_queue_task_fn that executes a C function in a thread pool worker and notifies event callbacks on the event loop thread upon completion.