### PR TITLE
#111: fix libuv reactor getaddrinfo result leak on cancel

### DIFF
--- a/fuzzy_tests/cross_topic/cancel_during_io.feature
+++ b/fuzzy_tests/cross_topic/cancel_during_io.feature
@@ -20,18 +20,14 @@ Feature: Cancel a coroutine that is blocked on real I/O
     coroutine "X" is completed
     no orphan coroutines
 
-  # NOTE: TCP-accept scenarios with zero-delay cancel are blocked on a
-  # libuv reactor leak (getaddrinfo result not freed when the awaiting
-  # coroutine is cancelled before the resolution is consumed). See issue
-  # #111. Reinstate the following two scenarios + the ms=0 example below
-  # once the reactor leak fix lands:
-  #
-  #   Scenario: cancel a coroutine blocked on TCP accept
-  #   Scenario: many accepters cancelled together
-  #   Scenario Outline ms=0 example
-  #
-  # The pipe-read scenario and the small-delay scenarios (ms=5, ms=50)
-  # do not race the addrinfo callback and stay enabled.
+  Scenario: cancel a coroutine blocked on TCP accept
+    Given a coroutine "S"
+      And a coroutine "K"
+     When coroutine "S" listens for one connection on a fresh socket
+      And coroutine "K" cancels coroutine "S"
+     Then counter "io_accept_ok_S" plus counter "io_accept_cancelled_S" plus counter "io_accept_failed_S" plus counter "io_accept_timeout_S" equals counter "io_accept_attempts_S"
+      And coroutine "S" is completed
+      And no orphan coroutines
 
   Scenario: cancel a coroutine blocked on pipe read
     Given a coroutine "R"
@@ -52,6 +48,25 @@ Feature: Cancel a coroutine that is blocked on real I/O
       And coroutine "S" is completed
       And no orphan coroutines
 
+  Scenario: many accepters cancelled together
+    Given a coroutine "S1"
+      And a coroutine "S2"
+      And a coroutine "S3"
+      And a coroutine "K"
+     When coroutine "S1" listens for one connection on a fresh socket
+      And coroutine "S2" listens for one connection on a fresh socket
+      And coroutine "S3" listens for one connection on a fresh socket
+      And coroutine "K" cancels coroutine "S1"
+      And coroutine "K" cancels coroutine "S2"
+      And coroutine "K" cancels coroutine "S3"
+     Then counter "io_accept_ok_S1" plus counter "io_accept_cancelled_S1" plus counter "io_accept_failed_S1" plus counter "io_accept_timeout_S1" equals counter "io_accept_attempts_S1"
+      And counter "io_accept_ok_S2" plus counter "io_accept_cancelled_S2" plus counter "io_accept_failed_S2" plus counter "io_accept_timeout_S2" equals counter "io_accept_attempts_S2"
+      And counter "io_accept_ok_S3" plus counter "io_accept_cancelled_S3" plus counter "io_accept_failed_S3" plus counter "io_accept_timeout_S3" equals counter "io_accept_attempts_S3"
+      And coroutine "S1" is completed
+      And coroutine "S2" is completed
+      And coroutine "S3" is completed
+      And no orphan coroutines
+
   Scenario Outline: vary cancel delay against accept
     Given a coroutine "S"
       And a coroutine "K"
@@ -64,5 +79,6 @@ Feature: Cancel a coroutine that is blocked on real I/O
 
     Examples:
       | ms |
+      | 0  |
       | 5  |
       | 50 |

--- a/libuv_reactor.c
+++ b/libuv_reactor.c
@@ -2969,7 +2969,17 @@ static bool libuv_dns_getaddrinfo_dispose(zend_async_event_t *event)
 		return true;
 	}
 
-	pefree((async_dns_addrinfo_t *) event, 0);
+	async_dns_addrinfo_t *addr_info = (async_dns_addrinfo_t *) event;
+
+	/* If consumer never picked up the result (e.g. coroutine cancelled between
+	 * on_addrinfo_event and dns_callback_resolve), event->result is still non-NULL
+	 * and owned by the event. Free it here to avoid leaking the libuv addrinfo. */
+	if (addr_info->event.result != NULL) {
+		uv_freeaddrinfo((struct addrinfo *) addr_info->event.result);
+		addr_info->event.result = NULL;
+	}
+
+	pefree(addr_info, 0);
 	return true;
 }
 

--- a/tests/pdo_pgsql/029-pdo_pgsql_pool_killed_concurrent.phpt
+++ b/tests/pdo_pgsql/029-pdo_pgsql_pool_killed_concurrent.phpt
@@ -57,10 +57,9 @@ foreach ($results as $r) {
 }
 
 // Pool cleanup after a terminated connection is asynchronous. Poll the
-// pool count for up to ~500ms instead of relying on a fixed delay, which
-// was racy on slower CI runners.
-for ($i = 0; $i < 50 && $pool->count() > 1; $i++) {
-    delay(10);
+// pool count for up to ~5s; 500ms was still racy on RELEASE_ZTS CI.
+for ($i = 0; $i < 200 && $pool->count() > 1; $i++) {
+    delay(25);
 }
 echo "Pool count: " . $pool->count() . "\n";
 echo "Done\n";

--- a/tests/pdo_pgsql/029-pdo_pgsql_pool_killed_concurrent.phpt
+++ b/tests/pdo_pgsql/029-pdo_pgsql_pool_killed_concurrent.phpt
@@ -57,9 +57,10 @@ foreach ($results as $r) {
 }
 
 // Pool cleanup after a terminated connection is asynchronous. Poll the
-// pool count for up to ~5s; 500ms was still racy on RELEASE_ZTS CI.
-for ($i = 0; $i < 200 && $pool->count() > 1; $i++) {
-    delay(25);
+// pool count for up to ~500ms instead of relying on a fixed delay, which
+// was racy on slower CI runners.
+for ($i = 0; $i < 50 && $pool->count() > 1; $i++) {
+    delay(10);
 }
 echo "Pool count: " . $pool->count() . "\n";
 echo "Done\n";


### PR DESCRIPTION
When the awaiting coroutine was cancelled between on_addrinfo_event and dns_callback_resolve picking up the result, the libuv-allocated addrinfo buffer leaked: dispose treated CALLBACK_DONE as "consumer owns it" and just pefree'd the event.

Fix is to make event->result the single source of ownership truth:

  event->result != NULL  -> event still owns the addrinfo
  event->result == NULL  -> handed over to consumer (or never delivered)

dispose now uv_freeaddrinfo's the result if still non-NULL. The handover to the consumer (clearing event->result) lives in main/network_async.c in the matching php-src commit.

Reinstates the three cancel_during_io scenarios that were temporarily removed in 6d0d397 to unblock CI: TCP-accept zero-delay cancel, the many-accepters variant, and the ms=0 example in the cancel-delay outline.