### PR TITLE
fix: preserve a closure's bound $this across thread transfer

### DIFF
--- a/tests/thread/058-spawn_thread_captured_bound_closure.phpt
+++ b/tests/thread/058-spawn_thread_captured_bound_closure.phpt
@@ -1,0 +1,56 @@
+--TEST--
+spawn_thread() - a captured $this-bound closure keeps its binding across transfer
+--SKIPIF--
+<?php
+if (!PHP_ZTS) die('skip ZTS required');
+if (!function_exists('Async\spawn_thread')) die('skip spawn_thread not available');
+?>
+--FILE--
+<?php
+
+use function Async\spawn;
+use function Async\spawn_thread;
+use function Async\await;
+
+class Greeter {
+    public string $name = 'world';
+
+    public function greet(): string {
+        return "hello {$this->name}";
+    }
+}
+
+/* The task closure is a free static closure transferred via the fcall
+ * snapshot. Its captured $bound, however, is a $this-bound closure: it
+ * travels as a bound variable and therefore goes through the generic
+ * closure transfer (closure_transfer_obj), not the task snapshot path.
+ *
+ * Regression: closure_transfer_obj built the snapshot with only
+ * fci_cache.function_handler set, dropping fci_cache.object — so the
+ * worker rebuilt an unbound closure and invoking it dereferenced a
+ * NULL $this. */
+$boot = function () {
+    eval('class Greeter { public string $name = "world"; public function greet(): string { return "hello {$this->name}"; } }');
+};
+
+spawn(function () use ($boot) {
+    $g = new Greeter();
+    $g->name = 'thread';
+
+    $bound = $g->greet(...);   // Closure bound to $g
+
+    $thread = spawn_thread(static function () use ($bound): string {
+        return $bound();
+    }, bootloader: $boot);
+
+    echo await($thread), "\n";
+
+    // The transferred binding is a deep copy — mutating it on the parent
+    // side afterwards must not have affected the worker's result above.
+    $g->name = 'mutated';
+    echo "parent: ", $g->greet(), "\n";
+});
+?>
+--EXPECT--
+hello thread
+parent: hello mutated

--- a/thread.c
+++ b/thread.c
@@ -3051,6 +3051,18 @@ static zend_object *closure_transfer_obj(
 		memset(&fcall, 0, sizeof(fcall));
 		fcall.fci_cache.function_handler = (zend_function *) func;
 
+		/* Preserve the closure's bound $this. thread_copy_callable reads the
+		 * bound instance from fci_cache.object; without this the snapshot is
+		 * built unbound and the destination thread recreates an object-less
+		 * closure — a method/object-bound closure then dereferences a NULL
+		 * $this on first use. */
+		zval closure_zv;
+		ZVAL_OBJ(&closure_zv, object);
+		zval *bound_this = zend_get_closure_this_ptr(&closure_zv);
+		if (bound_this != NULL && Z_TYPE_P(bound_this) == IS_OBJECT) {
+			fcall.fci_cache.object = Z_OBJ_P(bound_this);
+		}
+
 		async_thread_snapshot_t *snapshot = async_thread_snapshot_create(&fcall, NULL);
 		if (snapshot == NULL) {
 			return NULL;


### PR DESCRIPTION
## Bug

A `$this`-bound closure transferred to another thread through the **generic** closure-transfer path arrives **unbound**. Invoking a method- or object-bound closure in the destination thread then dereferences a `NULL` `$this` — SIGSEGV on the first `$this` access.

Reproduced end-to-end: an object-bound HTTP handler registered on `TrueAsync\HttpServer` with `setWorkers(N>1)` segfaults every worker on the first request. A direct `Async\ThreadPool` submit of an object-bound closure is **not** affected — the difference led straight to the cause.

## Cause

`closure_transfer_obj()` (the `transfer_obj` handler installed on `Closure`) builds the transfer snapshot like this:

```c
zend_fcall_t fcall;
memset(&fcall, 0, sizeof(fcall));
fcall.fci_cache.function_handler = (zend_function *) func;
async_thread_snapshot_t *snapshot = async_thread_snapshot_create(&fcall, NULL);
```

Only `fci_cache.function_handler` is set. But `thread_copy_callable()` reads the bound instance from `fci_cache.object`:

```c
zend_object *bound_obj = fcall->fci_cache.object;   /* NULL here */
...
if (bound_obj != NULL) { /* transfer bound_this */ }   /* skipped */
```

So `bound_this` stays `UNDEF`, and `async_thread_create_closure()` recreates an unbound closure.

`spawn_thread` / `ThreadPool` tasks are unaffected because they hand the snapshot a `zend_fcall_t` whose `fci_cache.object` is already resolved. The defect is specific to `closure_transfer_obj` — the path taken when a closure travels as a **bound variable, array element, argument, or channel message** (or via an extension's `ZEND_ASYNC_THREAD_TRANSFER_ZVAL`).

## Fix

Populate `fci_cache.object` from the closure's `this_ptr` before snapshotting. The snapshot/recreate machinery already handles `bound_this` end to end once it is given the instance — no other change needed.

## Test

`tests/thread/058-spawn_thread_captured_bound_closure.phpt` — a `$this`-bound closure captured as a bound variable of a `spawn_thread` task (forcing the generic path), invoked in the worker; also asserts the binding is a deep copy. Fails (NULL-`$this` deref) before the fix, passes after.