### PR TITLE
#129 io: skip 046-write_wakes_on_peer_reset on Windows

### DIFF
--- a/tests/stream/046-write_wakes_on_peer_reset.phpt
+++ b/tests/stream/046-write_wakes_on_peer_reset.phpt
@@ -7,6 +7,19 @@ the resulting POLLERR as UV_EBADF, which the reactor turns into a bare
 ASYNC_DISCONNECT. A write proxy's mask is ASYNC_WRITABLE only, so without
 treating a disconnect as terminal for every proxy the writer hangs forever.
 Found by the fuzzy-tests io/backpressure chaos suite.
+
+Skipped on Windows: the fix and this test target the POSIX poll/POLLERR
+path. On Windows (IOCP) the writer does not hang, but Winsock surfaces
+WSAECONNRESET to a write on a different schedule, so the "second fwrite
+fails" assertion does not hold. Whether Windows reliably signals the
+peer reset to a blocked writer needs separate verification — tracked in
+true-async/php-async#134.
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY === 'Windows') {
+    echo 'skip POSIX poll/POLLERR peer-reset path; Windows tracked in #134';
+}
+?>
 --FILE--
 <?php
 


### PR DESCRIPTION
`tests/stream/046-write_wakes_on_peer_reset.phpt` — the #129 item 1
regression test — fails on Windows. Pre-existing (it failed in #131 too,
masked by the `tests/io/083` failure that #133 has now fixed).

The test and the item 1 fix target the POSIX `poll`/`POLLERR` peer-reset
path. On Windows the writer does **not** hang (the catastrophic symptom
item 1 fixed does not reproduce), but Winsock surfaces `WSAECONNRESET` to
a write on a different schedule, so the "second fwrite fails" assertion
does not hold.

Skipped on Windows via `--SKIPIF--`; the POSIX path stays covered. Whether
Windows reliably signals a peer reset to a blocked writer is tracked in
#134.