### PR TITLE
test(thread_pool): de-flake reload bootloader test (075)

### DIFF
--- a/tests/thread_pool/075-reload_bootloader_fail.phpt
+++ b/tests/thread_pool/075-reload_bootloader_fail.phpt
@@ -24,19 +24,32 @@ $boot = function () use ($file, $flag) {
     }
 };
 
+// Workers boot on their own OS threads, so the marks appear asynchronously.
+// Wait for the expected count rather than a fixed delay — a loaded CI box can
+// lag well past any constant, but the count only ever grows toward the target.
+$marks     = static fn (): int => strlen(@file_get_contents($file) ?: '');
+$waitMarks = static function (int $want) use ($marks): int {
+    // Wall-clock bound, not an iteration count: under a saturated scheduler
+    // delay() advances little real time, and the worker threads need real
+    // time to be scheduled. Well within run-tests' own timeout.
+    $deadline = microtime(true) + 30.0;
+    while ($marks() < $want && microtime(true) < $deadline) {
+        delay(10);
+    }
+    return $marks();
+};
+
 $pool = new ThreadPool(2, 0, $boot);
-delay(300);
-$before = strlen(@file_get_contents($file) ?: '');
+$before = $waitMarks(2);   // both original workers booted
 
 touch($flag);
 $pool->reload();   // liveness: tokens come from the OLD cohort, not the dying replacements
 echo "reload returned\n";
 
-delay(300);
-$after = strlen(@file_get_contents($file) ?: '');
+$after = $waitMarks(4);    // both replacements attempted their boot before dying
 
 var_dump($before === 2);
-var_dump($after === 4);   // both replacements attempted their boot before dying
+var_dump($after === 4);
 
 $pool->close();
 @unlink($file);


### PR DESCRIPTION
## Flake

`tests/thread_pool/075-reload_bootloader_fail.phpt` failed intermittently on the `_FUZZ` job (`bool(true)` → `bool(false)` on the `$after === 4` assertion).

## Root cause — timing, not a reload bug

The test checks the boot-mark count 300 ms after `reload()`. By design `reload()` returns on **OLD-cohort exit tokens, not replacement boot** — that is the liveness guarantee (a replacement hung in its bootloader must not hang `reload()`). So the two replacements boot asynchronously on their own OS threads and may not have written their mark within a fixed 300 ms window. Under a loaded `-j$(nproc)` CI box one replacement lagged → 3 marks instead of 4.

Verified the product side is correct: both replacements always spawn and boot — reproduced `after=3` at ~5% under CPU stress with a fixed 300 ms wait, and `after=4` at 40/40 once the test waits for the condition.

## Fix (test-only)

Wait for the expected mark count on a **wall-clock deadline** instead of a constant delay. The count only grows toward the target, and a wall-clock (not iteration) bound survives a saturated scheduler where `delay()` barely advances real time. Assertions and `--EXPECT` are unchanged; a genuine lost replacement would still fail the test.

Reproduced the original flake locally under CPU stress; 40/40 green with the fix (and 15/15 via run-tests under sustained stress).