### PR TITLE
fix(thread_pool): graceful-shutdown a retiring sync worker so reload() completes (true-async/server#93)

### DIFF
--- a/thread_pool.c
+++ b/thread_pool.c
@@ -164,6 +164,17 @@ typedef struct {
 	async_thread_channel_t *channel;
 } thread_pool_worker_ctx_t;
 
+/* GCC -O2 -Wmaybe-uninitialized misfires across this function's deeply nested
+ * zend_try blocks — flagging both loop-local task pointers and the zend_try
+ * macro's own __orig_bailout (all set before their SETJMP and never changed,
+ * hence defined per C 7.13.2.1). The macro lives in Zend/zend.h and cannot be
+ * annotated here, so suppress the false positive for this function only.
+ * GCC-only: Clang doesn't have this warning group and MSVC would warn on the
+ * unknown pragma (C4068). */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 static void thread_pool_worker_handler(zend_async_thread_event_t *event, void *ctx)
 {
 	thread_pool_worker_ctx_t *wc = (thread_pool_worker_ctx_t *) ctx;
@@ -620,6 +631,18 @@ static void thread_pool_worker_handler(zend_async_thread_event_t *event, void *c
 			pool_scope = NULL;
 		}
 
+		/* Backstop for a retiring SYNC-mode worker: its tasks ran inline (no
+		 * per-task coroutine scope), so any coroutine still alive is a straggler
+		 * the bootloader spawned into the main scope (e.g. a DB-pool healthcheck
+		 * timer) that the server-side scope drain never reaches. Its live reactor
+		 * handle would keep AFTER_MAIN — and this worker's reload exit-token —
+		 * hung forever, so force graceful shutdown to cancel it. Coroutine-mode
+		 * pools instead drain their in-flight task coroutines below (see 077),
+		 * so they must not take this path. */
+		if (!pool->coroutine_mode) {
+			start_graceful_shutdown();
+		}
+
 		ZEND_ASYNC_RUN_SCHEDULER_AFTER_MAIN(false);
 
 		/* AFTER_MAIN drained all task coroutines (and ran their dispose,
@@ -676,6 +699,9 @@ static void thread_pool_worker_handler(zend_async_thread_event_t *event, void *c
 
 	pefree(wc, 1);
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 ///////////////////////////////////////////////////////////
 /// Coroutine-mode task: spawn + extended_dispose


### PR DESCRIPTION
A sync-mode pool worker posts its reload exit-token only after its scheduler drain (`RUN_SCHEDULER_AFTER_MAIN`) empties. That drain loops while any reactor handle is alive, so a never-ending coroutine the bootloader spawned into the worker's main scope (e.g. an async DB-pool healthcheck timer) keeps the drain — and thus `ThreadPool::reload()` — hung forever.

On the worker's `done:` exit, for sync-mode pools only (`!coroutine_mode`), call `start_graceful_shutdown()` before the drain: it cancels the main-scope stragglers and arms the drain escape valve, so the worker retires and `reload()` proceeds. Gated to sync mode — coroutine-mode pools must keep draining their in-flight task coroutines (`thread_pool/077`).

Also silences a GCC `-O2 -Wmaybe-uninitialized` false positive across the function's nested `zend_try`/`setjmp` blocks with a GCC-only scoped pragma.

Tests: `thread_pool` 78/79, hot-reload phpt (server) 5/5, zero compiler warnings.

Note: this exposes a separate, pre-existing bug — nested closures (`dynamic_func_defs`) are shared across worker threads, so a bootloader-spawned nested-closure coroutine can hit a cross-thread `run_time_cache` use-after-free during rotation. Tracked in #176; not addressed here.