### PR TITLE
fix(pool): healthcheck timer must not block graceful worker shutdown (true-async/server#93)

### DIFF
--- a/pool.c
+++ b/pool.c
@@ -667,6 +667,12 @@ static void pool_start_healthcheck_timer(async_pool_t *pool)
 		return;
 	}
 
+	/* The healthcheck timer is a background heartbeat, not application work.
+	 * Mark it HIDDEN so it does not count toward active_event_count — otherwise
+	 * an idle pool keeps the reactor loop alive and blocks a graceful worker
+	 * shutdown (e.g. on hot-reload), tripping the scheduler's loop-alive assert. */
+	ZEND_ASYNC_EVENT_SET_HIDDEN(&pool->healthcheck_timer->base);
+
 	/* Use inline callback embedded in pool structure */
 	pool->healthcheck_callback.ref_count = 1;
 	pool->healthcheck_callback.callback = pool_healthcheck_timer_callback;


### PR DESCRIPTION
## Problem

Under a **debug** build, hot-reloading workers can trip a scheduler assert:

```
Assertion failed: (zend_async_reactor_loop_alive_fn() == false && "The event loop must be stopped"),
function fiber_entry, file scheduler.c, line 2041.
```

Reproduced deterministically: a worker bootloader that warms an async **PDO connection pool** with `PDO::ATTR_POOL_HEALTHCHECK_INTERVAL > 0`, then `reload()`. With the interval set to `0` (no timer) the reload is clean — isolating the pool's healthcheck timer as the cause.

## Root cause

`pool_start_healthcheck_timer()` created the background heartbeat timer as a normal reactor event, so `libuv_timer_start` incremented `active_event_count`. On graceful shutdown `start_graceful_shutdown()` cancels coroutines, but nothing owns/closes this timer — the pool is only disposed later at PDO object teardown. So `ZEND_ASYNC_REACTOR_LOOP_ALIVE()` (`active_event_count > 0 && uv_loop_alive`) stayed `true` while the scheduler fiber finalized:

- **debug:** trips the loop-alive `ZEND_ASSERT` in `fiber_entry`.
- **release:** an idle pool needlessly keeps the retiring worker's loop alive.

The `ZEND_ASYNC_EVENT_F_HIDDEN` flag exists for exactly this — its doc names *"Background timers (e.g., garbage collection, health checks)"* as the canonical case — but the pool timer never set it.

## Fix

Mark the healthcheck timer `HIDDEN` right after creation. The timer still fires (HIDDEN only gates the `active_event_count` accounting, not `uv_timer_start`); it just no longer counts as application work for loop-alive / deadlock detection.

## Verification

- Repro (pool + interval=30 + reload ×N): was exit 134 with assert → now **0 asserts**, clean shutdown, all reloads succeed.
- server hot-reload phpt suite (051–054): **4/4 PASS**.
- PDO pool phpt suites (`pdo_pool_*`, `pool_*`): **0 failed** (17 passed, 8 skipped — need mysql/pgsql).