### PR TITLE
fix(future): race-safe remote_future_dispose — sever producer under the mutex before closing the trigger (true-async/server#93)

### DIFF
--- a/future.c
+++ b/future.c
@@ -2216,10 +2216,23 @@ static bool remote_future_dispose(zend_async_event_t *event)
 	zend_future_t *future = &remote->future;
 
 	if (remote->state != NULL) {
+		/* Sever the producer under the mutex before closing the trigger, so a
+		 * concurrent complete() becomes a no-op (mirrors state_object_free). */
+		zend_async_trigger_event_t *trigger_to_dispose = NULL;
+
+		ASYNC_MUTEX_LOCK(remote->state->mutex);
 		if (remote->state->trigger != NULL) {
-			remote->state->trigger->base.dispose(&remote->state->trigger->base);
+			trigger_to_dispose = remote->state->trigger;
 			remote->state->trigger = NULL;
+			zend_atomic_int_store(&remote->state->completed, 1);
 		}
+		remote->state->target_future = NULL;
+		ASYNC_MUTEX_UNLOCK(remote->state->mutex);
+
+		if (trigger_to_dispose != NULL) {
+			trigger_to_dispose->base.dispose(&trigger_to_dispose->base);
+		}
+
 		async_future_shared_state_delref(remote->state);
 		remote->state = NULL;
 	}


### PR DESCRIPTION
## Problem

`remote_future_dispose()` closed the shared-state's cross-thread trigger and dropped the state ref **without** first marking the state completed or detaching `target_future`. A producer thread completing the future at the same moment (`async_future_shared_state_complete`/`reject`) could then:
- ring a trigger that is being `uv_close`d, or
- resolve a `target_future` that the owner just freed.

So disposing an **unresolved** remote future was unsafe — only safe once it had already resolved.

## Fix

Mirror `async_future_state_object_free()`: under the shared-state mutex, grab the trigger, NULL it, set `completed = 1` and clear `target_future`, then dispose the trigger **outside** the lock. A concurrent `complete()`/`reject()` (both gated on `completed` under the same mutex) becomes a clean no-op.

This lets an owner dispose an unresolved remote future safely — e.g. `HttpServer` reaping the per-worker completion futures returned by `submit_internal()` on pool shutdown (true-async/server#93), which otherwise left their triggers armed on the parent reactor (loop-alive assert on debug / leaked libuv handle on release).

## Test

Covered end-to-end by the server suite (graceful_shutdown + reload → shutdown); no ABI change.