### PR TITLE
#183: pcntl_fork() reactor safety — reinit child loop + guard against live coroutines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-07-08
+
+### Fixed
+- **`pcntl_fork()` under an active reactor broke the child process (e.g. `php artisan tinker` / any PsySH REPL under laravel-spawn).** The child inherited the parent's libuv loop, whose epoll backend is shared with the parent, so blocking I/O in the child spun on stale/duplicated events and the REPL never processed input — it appeared to exit with no error. `pcntl_fork()` now reinitializes the loop in the child via `uv_loop_fork()` (ABI hook `zend_async_after_fork_child_fn`), giving it an independent, working reactor.
+
+### Changed
+- **`pcntl_fork()` now throws when a coroutine other than the main one is running.** An in-flight coroutine's reactor state and worker threads cannot survive `fork()`, so forking is refused with a clear `Error` instead of silently corrupting the child. Fork is permitted only when just the main coroutine is active (ABI hook `zend_async_before_fork_fn`). Requires ABI v0.24.0.
+
 ## [0.7.9] - 2026-07-07
 
 ### Fixed

--- a/async.c
+++ b/async.c
@@ -1727,6 +1727,37 @@ PHP_INI_END()
 
 /* Module registration */
 
+/* {{{ async_before_fork
+ *
+ * Runs in the parent before fork(). Forking is only safe when no coroutine other
+ * than the main one is alive — an in-flight coroutine's reactor state and worker
+ * threads cannot survive fork(). Returns false and throws otherwise. */
+static bool async_before_fork(void)
+{
+	if (ZEND_ASYNC_IS_OFF) {
+		return true;
+	}
+
+	zend_coroutine_t *coroutine;
+	ZEND_HASH_FOREACH_PTR(&ASYNC_G(coroutines), coroutine)
+	{
+		if (coroutine == NULL || ZEND_COROUTINE_IS_MAIN(coroutine) ||
+			coroutine == ZEND_ASYNC_SCHEDULER) {
+			continue;
+		}
+
+		zend_throw_error(NULL,
+				"Cannot fork(): %u coroutine(s) other than the main one are running. "
+				"fork() is only allowed when just the main coroutine is active.",
+				zend_hash_num_elements(&ASYNC_G(coroutines)) - 1);
+		return false;
+	}
+	ZEND_HASH_FOREACH_END();
+
+	return true;
+}
+/* }}} */
+
 ZEND_MINIT_FUNCTION(async)
 {
 	REGISTER_INI_ENTRIES();
@@ -1754,6 +1785,7 @@ ZEND_MINIT_FUNCTION(async)
 	async_api_register();
 	async_pool_api_register();
 	async_libuv_reactor_register();
+	zend_async_fork_register(async_before_fork, libuv_after_fork_child);
 
 	return SUCCESS;
 }

--- a/async.c
+++ b/async.c
@@ -1727,11 +1727,9 @@ PHP_INI_END()
 
 /* Module registration */
 
-/* {{{ async_before_fork
- *
- * Runs in the parent before fork(). Forking is only safe when no coroutine other
- * than the main one is alive — an in-flight coroutine's reactor state and worker
- * threads cannot survive fork(). Returns false and throws otherwise. */
+/* {{{ async_before_fork */
+/* Refuse to fork with any non-main coroutine alive: its in-flight reactor state
+ * and worker threads cannot survive fork(). Runs in the parent; throws on refusal. */
 static bool async_before_fork(void)
 {
 	if (ZEND_ASYNC_IS_OFF) {
@@ -1747,9 +1745,8 @@ static bool async_before_fork(void)
 		}
 
 		zend_throw_error(NULL,
-				"Cannot fork(): %u coroutine(s) other than the main one are running. "
-				"fork() is only allowed when just the main coroutine is active.",
-				zend_hash_num_elements(&ASYNC_G(coroutines)) - 1);
+				"Cannot fork() while coroutines other than the main one are running. "
+				"fork() is only allowed when just the main coroutine is active.");
 		return false;
 	}
 	ZEND_HASH_FOREACH_END();

--- a/libuv_reactor.c
+++ b/libuv_reactor.c
@@ -428,14 +428,9 @@ static void libuv_debug_dump_handle(uv_handle_t *handle, void *arg)
 }
 #endif
 
-/* {{{ libuv_after_fork_child
- *
- * Runs in a freshly-forked child. The child inherited the parent's libuv loop,
- * whose epoll/kqueue backend fd is shared with the parent — running it here would
- * steal the parent's events and corrupt both. libuv has already reset its global
- * threadpool (its own pthread_atfork child handler), so we only need to give the
- * loop a private backend via uv_loop_fork(). Fork is only permitted with the main
- * coroutine active (see async_before_fork), so no user handles are in flight. */
+/* {{{ libuv_after_fork_child */
+/* Child inherited the parent's libuv loop (shared epoll backend); give it its own
+ * via uv_loop_fork(). libuv already reset the threadpool (its own atfork handler). */
 void libuv_after_fork_child(void)
 {
 	if (!ASYNC_G(reactor_started)) {

--- a/libuv_reactor.c
+++ b/libuv_reactor.c
@@ -428,6 +428,24 @@ static void libuv_debug_dump_handle(uv_handle_t *handle, void *arg)
 }
 #endif
 
+/* {{{ libuv_after_fork_child
+ *
+ * Runs in a freshly-forked child. The child inherited the parent's libuv loop,
+ * whose epoll/kqueue backend fd is shared with the parent — running it here would
+ * steal the parent's events and corrupt both. libuv has already reset its global
+ * threadpool (its own pthread_atfork child handler), so we only need to give the
+ * loop a private backend via uv_loop_fork(). Fork is only permitted with the main
+ * coroutine active (see async_before_fork), so no user handles are in flight. */
+void libuv_after_fork_child(void)
+{
+	if (!ASYNC_G(reactor_started)) {
+		return;
+	}
+
+	uv_loop_fork(UVLOOP);
+}
+/* }}} */
+
 /* {{{ libuv_reactor_shutdown */
 bool libuv_reactor_shutdown(void)
 {

--- a/libuv_reactor.h
+++ b/libuv_reactor.h
@@ -245,6 +245,9 @@ struct _async_udp_req_t
 
 void async_libuv_reactor_register(void);
 
+/* Reinitializes the reactor loop in a freshly-forked child (uv_loop_fork). */
+void libuv_after_fork_child(void);
+
 /* Called by async_thread_run in the child thread after ts_free_thread, so
  * the registry entry vanishes only once the child is past TSRM/Zend access. */
 void async_libuv_thread_registry_remove(zend_async_thread_handle_t handle);

--- a/php_async.h
+++ b/php_async.h
@@ -49,8 +49,8 @@ PHP_ASYNC_API extern zend_class_entry *async_ce_fs_watcher;
 PHP_ASYNC_API extern zend_class_entry *async_ce_circuit_breaker_strategy;
 
 #define PHP_ASYNC_NAME "true_async"
-#define PHP_ASYNC_VERSION "0.7.9"
-#define PHP_ASYNC_NAME_VERSION "true async v0.7.9"
+#define PHP_ASYNC_VERSION "0.8.0"
+#define PHP_ASYNC_NAME_VERSION "true async v0.8.0"
 
 #define REACTOR_CHECK_INTERVAL (100 * 1000000) // ms in nanoseconds
 

--- a/tests/fork/001-fork_guard_active_coroutine.phpt
+++ b/tests/fork/001-fork_guard_active_coroutine.phpt
@@ -1,0 +1,30 @@
+--TEST--
+pcntl_fork() throws when a coroutine other than the main one is running
+--EXTENSIONS--
+pcntl
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY === 'Windows') echo "skip Unix-only test";
+?>
+--FILE--
+<?php
+
+use function Async\spawn;
+use function Async\delay;
+
+// A live non-main coroutine makes fork() unsafe: its in-flight reactor state
+// and worker threads cannot survive fork().
+$c = spawn(function () { delay(10000); });
+
+try {
+    pcntl_fork();
+    echo "FAIL: no exception\n";
+} catch (\Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+$c->cancel();
+
+?>
+--EXPECTF--
+Cannot fork(): %d coroutine(s) other than the main one are running. fork() is only allowed when just the main coroutine is active.

--- a/tests/fork/001-fork_guard_active_coroutine.phpt
+++ b/tests/fork/001-fork_guard_active_coroutine.phpt
@@ -26,5 +26,5 @@ try {
 $c->cancel();
 
 ?>
---EXPECTF--
-Cannot fork(): %d coroutine(s) other than the main one are running. fork() is only allowed when just the main coroutine is active.
+--EXPECT--
+Cannot fork() while coroutines other than the main one are running. fork() is only allowed when just the main coroutine is active.

--- a/tests/fork/002-fork_reactor_reinit_child.phpt
+++ b/tests/fork/002-fork_reactor_reinit_child.phpt
@@ -1,0 +1,37 @@
+--TEST--
+pcntl_fork() under an active reactor: the child gets an independent, working reactor
+--EXTENSIONS--
+pcntl
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY === 'Windows') echo "skip Unix-only test";
+?>
+--FILE--
+<?php
+
+use function Async\spawn;
+use function Async\await;
+use function Async\delay;
+
+// Activate the reactor, then settle so only the main coroutine remains.
+await(spawn(function () { delay(1); }));
+
+$pid = pcntl_fork();
+
+if ($pid === 0) {
+    // Child: it inherited the parent's libuv loop (shared epoll). The fork hook
+    // reinitializes it, so async I/O in the child must work on its own reactor.
+    $r = await(spawn(function () { delay(1); return 42; }));
+    exit($r === 42 ? 0 : 1);
+}
+
+$status = 0;
+pcntl_waitpid($pid, $status);
+
+echo "child exit code: ", pcntl_wexitstatus($status), "\n";
+echo "parent still alive\n";
+
+?>
+--EXPECT--
+child exit code: 0
+parent still alive

--- a/tests/fork/003-fork_async_off.phpt
+++ b/tests/fork/003-fork_async_off.phpt
@@ -1,0 +1,27 @@
+--TEST--
+pcntl_fork() is allowed unchanged when the async engine was never activated
+--EXTENSIONS--
+pcntl
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY === 'Windows') echo "skip Unix-only test";
+?>
+--FILE--
+<?php
+
+// No spawn/await: the async engine stays OFF, so fork() behaves like plain PHP
+// with no guard and no reactor reinit.
+$pid = pcntl_fork();
+
+if ($pid === 0) {
+    exit(7);
+}
+
+$status = 0;
+pcntl_waitpid($pid, $status);
+
+echo "child exit code: ", pcntl_wexitstatus($status), "\n";
+
+?>
+--EXPECT--
+child exit code: 7


### PR DESCRIPTION
Fixes #183.

## Problem

`pcntl_fork()` under an active reactor corrupts the child. Visible symptom: `php artisan tinker` / any PsySH REPL under laravel-spawn starts but never evaluates input and exits with no error — PsySH runs each evaluation in a `pcntl_fork()`ed child.

Root cause: the child inherits the parent's libuv loop (epoll backend shared with the parent), so blocking I/O in the child spins on stale/duplicated events. libuv does not support running a loop across `fork()`.

## Fix

Registers two fork ABI hooks (php-src ABI **v0.24.0**), called from `pcntl_fork()`:

- **`after_fork_child`** → `uv_loop_fork()` gives the child a private epoll, so its reactor is independent of the parent's. libuv already resets its own threadpool across fork.
- **`before_fork`** → throws when any coroutine other than the main one is running; their in-flight reactor state and worker threads cannot survive `fork()`. Fork is allowed only with the main coroutine active.

## Tests

`tests/fork/`:
- `001` guard throws with a live non-main coroutine
- `002` fork with only main alive → child runs async I/O on its reinitialized loop, both exit cleanly
- `003` plain fork when async never activated is unchanged

Verified: `php artisan tinker` (default pcntl forking) now evaluates input and exits cleanly; full `ext/async` + `ext/pcntl` suites green (no regressions).

## Cross-repo

Depends on true-async/php-src ABI v0.24.0, already merged to `true-async` and `true-async-stable`.
