### PR TITLE
fix(iterate): apply concurrency to Traversable, not only to arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`iterate()` ignored `concurrency` for every `Traversable`.** Generators, `Iterator` and `IteratorAggregate` ran strictly one callback at a time (arrays were fine): advancing a `zend_iterator` cancelled the spawning microtask and only uncancelled it if the move had suspended, so after the first non-suspending move no worker was ever spawned again.
+
 - **`current_context()` silently discarded everything written before the first coroutine.** With no scope to anchor to, every top-level call returned a fresh detached context, so `set()` wrote where nobody could read it. The scheduler is now started on demand, as `spawn()` already does.
 
 - **`iterate()` ran `concurrency + 1` callbacks at once and silently cancelled the last one still working.** The coroutine driving the iteration loop executes the callback but did not take a slot, so a callback slower than its peers was killed with `AsyncCancellation` and lost without a trace.

--- a/iterator.c
+++ b/iterator.c
@@ -219,10 +219,16 @@ void iterator_dtor(zend_async_microtask_t *microtask)
 //
 // End of the block for safe iterator modification.
 //
+// The microtask is uncancelled unconditionally: the move is over, so spawning is safe again. Tying this
+// to ref_count would leave the microtask cancelled forever whenever the move did not suspend -- which is
+// the usual case -- and no worker would ever be spawned again.
+// A changed ref_count means the scheduler consumed the microtask while it was cancelled, so it is no
+// longer queued and has to be queued again.
+//
 #define ITERATOR_SAFE_MOVING_END(iterator) \
 	(iterator)->state = ASYNC_ITERATOR_STARTED; \
+	(iterator)->microtask.is_cancelled = false; \
 	if (prev_ref_count != (iterator)->microtask.ref_count) { \
-		(iterator)->microtask.is_cancelled = false; \
 		ZEND_ASYNC_ADD_MICROTASK(&(iterator)->microtask); \
 	}
 

--- a/tests/iterate/018-iterate_traversable_concurrency.phpt
+++ b/tests/iterate/018-iterate_traversable_concurrency.phpt
@@ -1,0 +1,58 @@
+--TEST--
+iterate() - concurrency applies to Traversable, not only to arrays
+--FILE--
+<?php
+
+use function Async\spawn;
+use function Async\delay;
+use function Async\iterate;
+
+function items(int $n): Generator
+{
+    for ($i = 1; $i <= $n; $i++) {
+        yield $i;
+    }
+}
+
+echo "start\n";
+
+// Every move of a zend_iterator runs under ITERATOR_SAFE_MOVING, which cancels the spawning microtask.
+// It used to stay cancelled whenever the move did not suspend, so no worker was ever spawned again and
+// concurrency was silently a no-op for the whole Traversable half of `iterable`.
+spawn(function () {
+    foreach ([['array', fn() => range(1, 8)],
+              ['ArrayIterator', fn() => new ArrayIterator(range(1, 8))],
+              ['Generator', fn() => items(8)]] as [$name, $make]) {
+
+        $active = 0;
+        $peak = 0;
+        $seen = [];
+
+        iterate($make(), function ($value) use (&$active, &$peak, &$seen) {
+            $active++;
+
+            if ($active > $peak) {
+                $peak = $active;
+            }
+
+            delay(20);
+            $seen[] = $value;
+            $active--;
+        }, concurrency: 4);
+
+        sort($seen);
+        echo $name, ": peak $peak, values ", implode(',', $seen), "\n";
+    }
+
+    echo "done\n";
+});
+
+echo "end\n";
+?>
+--EXPECT--
+start
+end
+array: peak 4, values 1,2,3,4,5,6,7,8
+ArrayIterator: peak 4, values 1,2,3,4,5,6,7,8
+Generator: peak 4, values 1,2,3,4,5,6,7,8
+done

--- a/tests/iterate/019-iterate_suspending_iterator.phpt
+++ b/tests/iterate/019-iterate_suspending_iterator.phpt
@@ -1,0 +1,65 @@
+--TEST--
+iterate() - an iterator that suspends inside its own methods is still advanced safely
+--FILE--
+<?php
+
+use function Async\spawn;
+use function Async\delay;
+use function Async\iterate;
+
+// Suspending inside rewind()/current()/next() is what ITERATOR_SAFE_MOVING guards against: while the
+// position is undefined no worker may be spawned. Uncancelling the microtask at the end of a move must
+// not weaken that -- every value has to be delivered exactly once.
+final class SuspendingIterator implements Iterator
+{
+    private int $i = 1;
+
+    public function __construct(private int $n) {}
+
+    public function rewind(): void { delay(5); $this->i = 1; }
+
+    public function valid(): bool { return $this->i <= $this->n; }
+
+    public function current(): mixed { delay(5); return $this->i; }
+
+    public function key(): mixed { return $this->i; }
+
+    public function next(): void { delay(5); $this->i++; }
+}
+
+echo "start\n";
+
+spawn(function () {
+    foreach ([1, 3] as $concurrency) {
+        $active = 0;
+        $peak = 0;
+        $seen = [];
+
+        iterate(new SuspendingIterator(6), function ($value) use (&$active, &$peak, &$seen) {
+            $active++;
+
+            if ($active > $peak) {
+                $peak = $active;
+            }
+
+            delay(20);
+            $seen[] = $value;
+            $active--;
+        }, concurrency: $concurrency);
+
+        sort($seen);
+        echo "concurrency $concurrency: values ", implode(',', $seen),
+             ", within limit: ", var_export($peak <= $concurrency, true), "\n";
+    }
+
+    echo "done\n";
+});
+
+echo "end\n";
+?>
+--EXPECT--
+start
+end
+concurrency 1: values 1,2,3,4,5,6, within limit: true
+concurrency 3: values 1,2,3,4,5,6, within limit: true
+done


### PR DESCRIPTION
Found while investigating #186 — not in the original bug report, and it predates that fix.

## Symptom

`concurrency:` is silently a no-op for the entire `Traversable` half of `iterable`. Only plain arrays get any parallelism:

```
array          c=4 peak=4  61ms
ArrayIterator  c=4 peak=1 243ms      <- 4x slower than asked for
IteratorAggr   c=4 peak=1 244ms
Generator      c=4 peak=1 244ms
```

Nothing is lost or thrown — the work just runs strictly one callback at a time, so the only visible effect is that `iterate()` is as slow as a `foreach`.

## Cause

Every move of a `zend_iterator` runs under `ITERATOR_SAFE_MOVING`, which sets `microtask.is_cancelled = true` so that no worker is spawned while the iterator position is undefined. That guard is legitimate: a user-land iterator may suspend inside `rewind()`/`current()`/`next()`.

But `ITERATOR_SAFE_MOVING_END` uncancelled the microtask **only if the move had changed `microtask.ref_count`** — that is, only if the scheduler had actually consumed the microtask while it was cancelled:

```c
#define ITERATOR_SAFE_MOVING_END(iterator) \
	(iterator)->state = ASYNC_ITERATOR_STARTED; \
	if (prev_ref_count != (iterator)->microtask.ref_count) { \
		(iterator)->microtask.is_cancelled = false; \   /* <- only here */
		ZEND_ASYNC_ADD_MICROTASK(&(iterator)->microtask); \
	}
```

A move that does not suspend — the usual case — leaves `ref_count` untouched. So from the very first move (`rewind()`) onwards `is_cancelled` stayed `true`, `execute_microtasks()` skipped the handler forever, and no worker was ever spawned again. Confirmed by instrumentation: `iterator_microtask()` never runs even once for a `Traversable`.

Arrays never take this path — they iterate a `target_hash` with no `SAFE_MOVING` blocks — which is why the bug was invisible there.

## Fix

Uncancelling is now unconditional: the move is over, so spawning is safe again. The `ref_count` check keeps its real job — a changed count means the microtask was consumed while cancelled and therefore has to be queued again.

The guard itself is untouched: during a move the state is `MOVING` and the microtask is cancelled, so an iterator that suspends inside its own methods still gets no workers spawned underneath it.

## Tests

- `018-iterate_traversable_concurrency.phpt` — array / `ArrayIterator` / `Generator` all reach the requested peak. Fails on the unfixed build with `peak 1`.
- `019-iterate_suspending_iterator.phpt` — an `Iterator` that suspends inside `rewind()`/`current()`/`next()` still delivers every value exactly once and stays within the limit. This one **passes on the unfixed build too, by design**: it is not a regression test but a guard on the invariant this change could plausibly break.

Verified beyond the .phpt suite on real shapes: generators at concurrency 0/1/4, `IteratorAggregate`, exception propagation out of a Traversable, early stop via `return false`, nested `iterate()` over generators, and an iterator suspending in its own methods (exact values, repeated runs).

Full `ext/async/tests`: 20/20 in `iterate`, no new failures overall. The 3 that fail (`curl/063`, `curl/064`, `io/082`) fail identically on a pristine baseline.