### PR TITLE
fix(context): root_context() is the main Scope's context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`root_context()` was not the main Scope's context and could not be seen by `find()`.** It lived in a global of its own, outside the Scope tree, so `find()` — which walks the Scope chain — never reached it. It is now the main Scope's context: `root_context() === current_context()` at top level, and values set on it are visible from every coroutine that inherits from the main Scope.
+
 - **`current_context()` silently discarded everything written before the first coroutine.** With no scope to anchor to, every top-level call returned a fresh detached context, so `set()` wrote where nobody could read it. The scheduler is now started on demand, as `spawn()` already does.
 
 - **`iterate()` ran `concurrency + 1` callbacks at once and silently cancelled the last one still working.** The coroutine driving the iteration loop executes the callback but did not take a slot, so a callback slower than its peers was killed with `AsyncCancellation` and lost without a trace.

--- a/async.c
+++ b/async.c
@@ -880,11 +880,25 @@ PHP_FUNCTION(Async_root_context)
 	THROW_IF_ASYNC_OFF;
 	THROW_IF_SCHEDULER_CONTEXT;
 
-	if (ASYNC_G(root_context) == NULL) {
-		ASYNC_G(root_context) = (zend_async_context_t *) async_context_new();
+	// The root context is the context of the main scope. Holding it in a global of its own put it outside
+	// the scope tree, where find() -- which walks scope->parent_scope -- could never reach it.
+	SCHEDULER_LAUNCH;
+
+	zend_async_scope_t *scope = ZEND_ASYNC_MAIN_SCOPE;
+
+	if (UNEXPECTED(scope == NULL)) {
+		async_throw_error("The main scope is not defined");
+		RETURN_THROWS();
 	}
 
-	async_context_t *context = (async_context_t *) ASYNC_G(root_context);
+	if (scope->context == NULL) {
+		async_context_t *context = async_context_new();
+		context->scope = scope;
+		scope->context = &context->base;
+		RETURN_OBJ_COPY(&context->std);
+	}
+
+	async_context_t *context = (async_context_t *) scope->context;
 	RETURN_OBJ_COPY(&context->std);
 }
 
@@ -1695,7 +1709,6 @@ static PHP_GINIT_FUNCTION(async)
 	async_globals->signal_handlers = NULL;
 	async_globals->signal_events = NULL;
 	async_globals->process_events = NULL;
-	async_globals->root_context = NULL;
 	/* Maximum number of coroutines in the concurrent iterator */
 	async_globals->default_concurrency = 32;
 
@@ -1813,12 +1826,6 @@ PHP_MINFO_FUNCTION(async)
 
 PHP_RSHUTDOWN_FUNCTION(async)
 {
-	if (ASYNC_G(root_context) != NULL) {
-		async_context_t *root_context = (async_context_t *) ASYNC_G(root_context);
-		ASYNC_G(root_context) = NULL;
-		OBJ_RELEASE(&root_context->std);
-	}
-
 	async_cpu_usage_reset_state();
 
 	return SUCCESS;

--- a/async.stub.php
+++ b/async.stub.php
@@ -181,8 +181,19 @@ function loadavg(): ?array {}
 
 function timeout(int $ms): Awaitable {}
 
+/**
+ * Returns the context of the current Scope.
+ *
+ * Values set here are visible to every coroutine below this Scope, because find() walks up the Scope
+ * chain. At top level this is the main Scope, so it returns the same object as root_context().
+ */
 function current_context(): Context {}
 
+/**
+ * Returns the context of the current coroutine.
+ *
+ * Unlike current_context(), this one belongs to the coroutine alone and is not inherited by anybody.
+ */
 function coroutine_context(): Context {}
 
 /**
@@ -196,7 +207,11 @@ function current_coroutine(): Coroutine {}
 //function finally(\Closure $callback): void {}
 
 /**
- * Returns the root Scope.
+ * Returns the context of the main Scope, the root of the Scope tree.
+ *
+ * Values set here are reachable through find() from every coroutine that inherits from the main Scope,
+ * which is all of them except those in a deliberately detached `new Scope()`. Those still reach it by
+ * calling root_context() directly.
  */
 function root_context(): Context {}
 

--- a/async_API.c
+++ b/async_API.c
@@ -221,12 +221,6 @@ static bool engine_shutdown(void)
 	zend_hash_destroy(&ASYNC_G(deadlock_channels));
 	zend_hash_destroy(&ASYNC_G(thread_channels));
 
-	if (ASYNC_G(root_context) != NULL) {
-		async_context_t *root_context = (async_context_t *) ASYNC_G(root_context);
-		ASYNC_G(root_context) = NULL;
-		OBJ_RELEASE(&root_context->std);
-	}
-
 	// async_host_name_list_dtor();
 	return true;
 }

--- a/async_arginfo.h
+++ b/async_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit async.stub.php instead.
- * Stub hash: 4164d2d438cd19d3005883636e5bc68db35ac954 */
+ * Stub hash: 73a3f3a9a874ef0399809a77256792435ef5086e */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_Async_spawn, 0, 1, Async\\Coroutine, 0)
 	ZEND_ARG_TYPE_INFO(0, task, IS_CALLABLE, 0)

--- a/php_async.h
+++ b/php_async.h
@@ -92,8 +92,6 @@ HashTable coroutines;
 zend_fiber_transfer *main_transfer;
 /* The main flow stack */
 zend_vm_stack main_vm_stack;
-/* System root context */
-zend_async_context_t *root_context;
 /* The default concurrency */
 int default_concurrency;
 

--- a/tests/context/010-root_context_is_main_scope.phpt
+++ b/tests/context/010-root_context_is_main_scope.phpt
@@ -1,0 +1,32 @@
+--TEST--
+root_context() - is the main Scope's context and is reachable through find()
+--FILE--
+<?php
+
+use function Async\spawn;
+use function Async\await;
+use function Async\root_context;
+use function Async\current_context;
+
+// root_context() used to live in a global of its own, outside the Scope tree, so find() -- which walks
+// scope->parent_scope -- could never reach it. It is the main Scope's context.
+root_context()->set('cfg', 'X');
+
+echo "root is current at top level: ", var_export(root_context() === current_context(), true), "\n";
+echo "plain coroutine:   ", var_export(await(spawn(fn() => current_context()->find('cfg'))), true), "\n";
+
+$inherited = Async\Scope::inherit();
+echo "Scope::inherit():  ", var_export(await($inherited->spawn(fn() => current_context()->find('cfg'))), true), "\n";
+
+// A plain `new Scope()` is a detached root on purpose, so it does not inherit the context either --
+// but root_context() still reaches it directly.
+$detached = new Async\Scope();
+echo "new Scope():       ", var_export(await($detached->spawn(fn() => current_context()->find('cfg'))), true), "\n";
+echo "new Scope() direct: ", var_export(await($detached->spawn(fn() => root_context()->find('cfg'))), true), "\n";
+?>
+--EXPECT--
+root is current at top level: true
+plain coroutine:   'X'
+Scope::inherit():  'X'
+new Scope():       NULL
+new Scope() direct: 'X'


### PR DESCRIPTION
Item 2 of the tutorial bug reports. The docs were right; the code was not.

## Symptom

`root_context()` is invisible to `find()` from anywhere:

```php
$c = spawn(function () { root_context()->set('cfg', 'X'); });
await($c);

var_dump(await(spawn(fn() => current_context()->find('cfg'))));  // NULL
var_dump(await(spawn(fn() => root_context()->find('cfg'))));     // 'X' — only directly
```

And `root_context() !== current_context()` at top level, which it should be — they are two different objects.

## Cause

`root_context()` kept its context in a global of its own — `ASYNC_G(root_context)` — created lazily by the function itself and **never attached to any Scope**.

`find()` resolves a key by walking `context->scope->parent_scope` and checking each Scope's context. A context that belongs to no Scope is therefore unreachable *by construction*: whatever you write to it is readable only by calling `root_context()` again.

So there were two parallel roots — the main Scope's context (which coroutines do see) and this global (which nothing sees).

## Fix

The root context *is* the main Scope's context — which is what the docblock already said (*"Returns the root Scope"*). Making it so, everything falls out of the Scope tree with no extra machinery:

- `root_context() === current_context()` at top level;
- every Scope chain terminates at the main Scope (`scope.c` gives a parentless Scope `MAIN_SCOPE` as parent), so `find()` reaches it from any coroutine that inherits from it.

The `ASYNC_G(root_context)` global is removed rather than kept in sync, so there is no second place for a root context to live.

## Semantics, verified

| | |
|---|---|
| `root_context() === current_context()` at top level | `true` |
| plain coroutine, `find('cfg')` | `'X'` |
| `Scope::inherit()`, `find('cfg')` | `'X'` |
| `new Scope()`, `find('cfg')` | `NULL` |
| `new Scope()`, `root_context()->find('cfg')` | `'X'` |

A plain `new Scope()` is a **detached root on purpose** (`async_new_scope(NULL, …)`) — that is the whole reason `Scope::inherit()` exists as a separate API — so its coroutines do not inherit the context either. They still reach the root by calling `root_context()` directly. The stub docblocks are updated to say this precisely instead of "visible from any context", which was the overstatement in the docs.

## Tests

New `tests/context/010-root_context_is_main_scope.phpt` pins all five rows above.

Full `ext/async/tests`: no new failures. The 3 that fail (`curl/063`, `curl/064`, `io/082`) fail identically on a pristine baseline.