### PR TITLE
docs(pool): acquire() reports a timeout as TimeoutException, not PoolException

### DIFF
--- a/pool.stub.php
+++ b/pool.stub.php
@@ -46,9 +46,15 @@ final class Pool implements \Countable, CircuitBreaker
      *
      * Waits if no resource available and pool is at max capacity.
      *
+     * A timeout is not a pool failure — the pool is healthy, it is merely busy — so it is reported as
+     * TimeoutException, the same way every other deadline in the extension is. PoolException is reserved
+     * for the pool itself being unusable. Note that TimeoutException extends Exception, not
+     * PoolException, so catching PoolException alone will not catch a timeout.
+     *
      * @param int $timeout Max wait time in ms (0 = infinite)
      * @return mixed The acquired resource
-     * @throws PoolException If pool is closed or timeout
+     * @throws PoolException If the pool is closed or was never initialised
+     * @throws TimeoutException If no resource became available within $timeout
      */
     public function acquire(int $timeout = 0): mixed {}
 

--- a/tests/pool/055-pool_acquire_timeout_exception.phpt
+++ b/tests/pool/055-pool_acquire_timeout_exception.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Pool: acquire() reports a timeout as TimeoutException, a dead pool as PoolException
+--FILE--
+<?php
+
+use Async\Pool;
+
+// A timeout is not a pool failure -- the pool is healthy, just busy -- so it is a TimeoutException,
+// like every other deadline in the extension. PoolException means the pool itself is unusable.
+$pool = new Pool(factory: fn() => new stdClass(), max: 1);
+$held = $pool->acquire();
+
+try {
+    $pool->acquire(timeout: 50);
+    echo "timeout: NOT THROWN\n";
+} catch (Throwable $exception) {
+    echo "timeout: ", $exception::class, "\n";
+    echo "  is a PoolException: ", var_export($exception instanceof Async\PoolException, true), "\n";
+}
+
+$pool->close();
+
+try {
+    $pool->acquire();
+    echo "closed: NOT THROWN\n";
+} catch (Throwable $exception) {
+    echo "closed: ", $exception::class, "\n";
+}
+?>
+--EXPECT--
+timeout: Async\TimeoutException
+  is a PoolException: false
+closed: Async\PoolException


### PR DESCRIPTION
Item 4 of the tutorial bug reports. Unlike the others, the **code is right and the contract is wrong**.

## The discrepancy

`pool.stub.php` promised — and the site docs repeated:

```php
 * @throws PoolException If pool is closed or timeout
public function acquire(int $timeout = 0): mixed {}
```

What actually happens:

```php
$pool = new Pool(factory: fn() => new stdClass(), max: 1);
$r = $pool->acquire();
try {
    $pool->acquire(timeout: 100);
} catch (Throwable $e) {
    echo get_class($e);   // Async\TimeoutException
}
```

This is worse than a cosmetic doc bug: `TimeoutException extends Exception`, **not** `PoolException`, so the `catch (PoolException)` the docs told you to write catches nothing at all.

## Which side is wrong?

The contract is. `PoolException` is what the extension raises when the pool itself is unusable — *"Pool is closed"*, *"Pool is not initialized"*, *"Failed to create pool resource"*. Every existing use means: something is wrong with the pool.

A timeout means the opposite. The pool is healthy; it is merely busy. You asked to wait at most N ms and the wait expired — that is your deadline, not the pool's fault. The two are also handled differently by a caller: a timeout you retry or back off from, a closed pool you do not. And a deadline is reported the same way everywhere else in the extension.

So `TimeoutException` is the right exception, and this PR fixes the promise rather than the behaviour.

## Change

- `acquire()`'s docblock now documents both outcomes separately, and explicitly warns that `TimeoutException` is not a `PoolException`, so `catch (PoolException)` will not catch it.
- New `tests/pool/055-pool_acquire_timeout_exception.phpt` pins both halves — a timeout raises `TimeoutException` and is *not* a `PoolException`; a closed pool raises `PoolException` — so the contract cannot drift again.

The site docs (`ru/docs/components/pool.html`) still need the same correction; that is outside this repo.

Full `ext/async/tests/pool`: 55/55.