### PR TITLE
docs(stub): document the three APIs the tutorials guessed wrong

### DIFF
--- a/async.stub.php
+++ b/async.stub.php
@@ -179,6 +179,17 @@ function cpu_usage(): array {}
  */
 function loadavg(): ?array {}
 
+/**
+ * Creates a cancellation token that trips after $ms.
+ *
+ * The token does nothing on its own — calling timeout() and letting the time pass throws nothing. It only
+ * has an effect once it is handed to an operation as a cancellation argument:
+ *
+ *     await($coroutine, timeout(2000));
+ *
+ * When it trips, the awaited operation is cancelled, so the caller sees OperationCanceledException with a
+ * TimeoutException as its getPrevious(). It is not a TimeoutException itself.
+ */
 function timeout(int $ms): Awaitable {}
 
 function current_context(): Context {}

--- a/async_arginfo.h
+++ b/async_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit async.stub.php instead.
- * Stub hash: 4164d2d438cd19d3005883636e5bc68db35ac954 */
+ * Stub hash: a18e5e8e1cbda7838bb830c323d38bf040cda9cb */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_Async_spawn, 0, 1, Async\\Coroutine, 0)
 	ZEND_ARG_TYPE_INFO(0, task, IS_CALLABLE, 0)

--- a/scope.stub.php
+++ b/scope.stub.php
@@ -57,6 +57,17 @@ final class Scope implements ScopeProvider
 
     public function cancel(?AsyncCancellation $cancellationError = null): void {}
 
+    /**
+     * Waits until every coroutine in this Scope has finished.
+     *
+     * The cancellation token is mandatory, not optional: a Scope has no deadline of its own, so without one
+     * a stuck child would hang the caller forever. Pass timeout() to bound the wait:
+     *
+     *     $scope->awaitCompletion(timeout(5000));
+     *
+     * @param Awaitable $cancellation Token that aborts the wait; when it trips, OperationCanceledException
+     *                                is thrown and the Scope itself keeps running.
+     */
     public function awaitCompletion(Awaitable $cancellation): void {}
 
     public function awaitAfterCancellation(?callable $errorHandler = null, ?Awaitable $cancellation = null): void {}
@@ -69,6 +80,14 @@ final class Scope implements ScopeProvider
 
     /**
      * Sets an error handler that is called when an exception is passed to the Scope from one of its child coroutines.
+     *
+     * The handler receives three arguments, not just the exception:
+     *
+     *     $scope->setExceptionHandler(function (Scope $scope, Coroutine $coroutine, \Throwable $error) { … });
+     *
+     * A single-parameter closure type-errors on the first failure, when it is far too late to notice.
+     *
+     * @param callable $exceptionHandler fn(Scope $scope, Coroutine $coroutine, \Throwable $error): void
      */
     public function setExceptionHandler(callable $exceptionHandler): void {}
 

--- a/scope_arginfo.h
+++ b/scope_arginfo.h
@@ -1,5 +1,5 @@
-/* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a93e0b70e865dea520f8d9d22e73b6640e1c0ebc */
+/* This is a generated file, edit scope.stub.php instead.
+ * Stub hash: c2099c980283b2ef42817380a270d7e1f5c3919a */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Async_ScopeProvider_provideScope, 0, 0, Async\\Scope, 1)
 ZEND_END_ARG_INFO()
@@ -159,9 +159,9 @@ static zend_class_entry *register_class_Async_Scope(zend_class_entry *class_entr
 	zend_class_implements(class_entry, 1, class_entry_Async_ScopeProvider);
 
 
-	zend_string *attribute_name_Override_func_providescope_0 = zend_string_init_interned("Override", sizeof("Override") - 1, 1);
+	zend_string *attribute_name_Override_func_providescope_0 = zend_string_init_interned("Override", sizeof("Override") - 1, true);
 	zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "providescope", sizeof("providescope") - 1), attribute_name_Override_func_providescope_0, 0);
-	zend_string_release(attribute_name_Override_func_providescope_0);
+	zend_string_release_ex(attribute_name_Override_func_providescope_0, true);
 
 	return class_entry;
 }


### PR DESCRIPTION
Items 6, 7 and 11 of the tutorial bug reports. All three trace back to the same root: **the stub says nothing, so the docs author guessed.** Fixing them only on the site would leave the next author to guess again.

## What was undocumented

**`timeout()`** — no docblock at all. The tutorial concluded it throws `TimeoutException` on its own, and built a whole chapter around that:

```php
try {
    timeout(2000);          // throws nothing, ever
} catch (TimeoutException $e) { }
```

It returns a token. Only when the token is handed to an operation does anything happen, and what the caller then sees is `OperationCanceledException` with a `TimeoutException` as `getPrevious()` — not a `TimeoutException`.

**`Scope::awaitCompletion(Awaitable $cancellation)`** — no docblock. The argument is **mandatory**, which the docs missed completely, so every example in them dies with `ArgumentCountError`.

**`Scope::setExceptionHandler()`** — had a docblock saying what the handler is *for*, but never its signature. It is called with `(Scope, Coroutine, Throwable)`. The one-parameter closure the docs show type-errors on the first failure — i.e. exactly when you least want a second bug.

## Verified, not assumed

Each statement added was checked against the build first. In particular, for `awaitCompletion()` I documented what happens when the token trips, having confirmed it:

```
awaitCompletion(timeout(100)): Async\OperationCanceledException
  getPrevious():              Async\TimeoutException
  scope isCancelled:          false
  scope isFinished:           false
  child finished anyway
```

So the wait aborts, but the Scope is **not** cancelled and its children keep running. That is now written down.

## Not touched, deliberately

Two other reported "doc bugs" turned out to be already correct in the stub, and are purely site-side errors:

- `CircuitBreakerStrategy` — all three methods (including `shouldRecover()`) are declared and documented in `async.stub.php`.
- `TaskGroup` — `$queueLimit` is fully documented, and `awaitCompletion()` already states *"The group must be closed before calling this method"* with `@throws AsyncException`.

## Note on the diff

Regenerating the arginfo also pulls `scope_arginfo.h` up to date with php-src's current `gen_stub.php` (`zend_string_release_ex`, file header line). That hunk is generator output, not hand-written — the committed file had simply drifted behind the generator.

Full `ext/async/tests`: no new failures. The 3 that fail (`curl/063`, `curl/064`, `io/082`) fail identically on a pristine baseline.