### PR TITLE
fix(channel): make foreach over a Channel survive a close, and not segfault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`foreach` over a `Channel` broke on the ordinary producer/consumer pattern.** Closing a channel while a consumer was parked in the loop left the wake-up `ChannelException` pending, so it escaped `foreach` uncaught — and surfaced against the producer's `close()`, which had done nothing wrong. An explicit `close()` now ends the iteration cleanly, while a deadlock or a disposal still propagates.
+
+- **Segfault: `foreach` over a `Channel` as the first async operation.** The loop reaches the iterator straight from `FE_RESET`, bypassing the guard `send()`/`recv()` run, so with no main coroutine yet it parked a `NULL` coroutine. It now starts the scheduler like every other blocking channel operation.
+
 - **`root_context()` was not the main Scope's context and could not be seen by `find()`.** It lived in a global of its own, outside the Scope tree, so `find()` — which walks the Scope chain — never reached it. It is now the main Scope's context: `root_context() === current_context()` at top level, and values set on it are visible from every coroutine that inherits from the main Scope.
 
 - **`iterate()` ignored `concurrency` for every `Traversable`.** Generators, `Iterator` and `IteratorAggregate` ran strictly one callback at a time (arrays were fine): advancing a `zend_iterator` cancelled the spawning microtask and only uncancelled it if the move had suspended, so after the first non-suspending move no worker was ever spawned again.

--- a/channel.c
+++ b/channel.c
@@ -798,6 +798,13 @@ retry:
 	CHANNEL_WAIT_FOR_DATA(channel, 0);
 
 	if (EG(exception)) {
+		// An explicit close() is how iteration ends, not a failure, so the exception the waiter was woken
+		// with is consumed here and foreach() finishes cleanly. Anything else -- a deadlock, a disposal, a
+		// cancellation -- is left pending and propagates out of the loop, where it belongs.
+		if (EG(exception)->ce == async_ce_channel_exception && channel->close_reason == CHANNEL_CLOSE_EXPLICIT) {
+			zend_clear_exception();
+		}
+
 		iterator->valid = false;
 		return;
 	}
@@ -828,6 +835,17 @@ static zend_object_iterator *channel_get_iterator(zend_class_entry *ce, zval *ob
 	if (by_ref) {
 		zend_throw_error(NULL, "Cannot iterate channel by reference");
 		return NULL;
+	}
+
+	// foreach() reaches this handler straight from FE_RESET, bypassing send()/recv() and the
+	// ENSURE_COROUTINE_CONTEXT they run. Iterating parks the caller on the channel just like recv() does,
+	// so the main coroutine has to exist first -- otherwise channel_wait_for() suspends a NULL coroutine.
+	if (UNEXPECTED(ZEND_ASYNC_CURRENT_COROUTINE == NULL)) {
+		async_scheduler_launch();
+
+		if (UNEXPECTED(EG(exception) != NULL)) {
+			return NULL;
+		}
 	}
 
 	channel_iterator_t *iterator = ecalloc(1, sizeof(channel_iterator_t));

--- a/tests/channel/070-channel_foreach_close_during_iteration.phpt
+++ b/tests/channel/070-channel_foreach_close_during_iteration.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Channel: foreach ends cleanly when the channel is closed while the consumer is parked
+--FILE--
+<?php
+
+use function Async\spawn;
+use function Async\await;
+use function Async\delay;
+
+echo "start\n";
+
+// The iterator parks in channel_wait_for() and is woken with a ChannelException when close() lands.
+// It used to stop the loop but leave that exception pending, so it escaped foreach() uncaught --
+// and surfaced against the producer's close(), which had done nothing wrong.
+$channel = new Async\Channel(2);
+
+$consumer = spawn(function () use ($channel) {
+    foreach ($channel as $value) {
+        echo "got: $value\n";
+    }
+
+    echo "loop finished normally\n";
+});
+
+$producer = spawn(function () use ($channel) {
+    delay(20);
+    $channel->send('a');
+    $channel->send('b');
+    delay(20);
+    $channel->close();
+    echo "producer closed\n";
+});
+
+await($producer);
+await($consumer);
+
+echo "done\n";
+?>
+--EXPECT--
+start
+got: a
+got: b
+producer closed
+loop finished normally
+done

--- a/tests/channel/071-channel_foreach_outside_coroutine.phpt
+++ b/tests/channel/071-channel_foreach_outside_coroutine.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Channel: foreach as the first async operation starts the scheduler instead of suspending a NULL coroutine
+--FILE--
+<?php
+
+echo "start\n";
+
+// foreach() reaches ce->get_iterator straight from FE_RESET, bypassing recv()'s ENSURE_COROUTINE_CONTEXT.
+// Iterating here is the very first async operation, so there is no main coroutine yet: the iterator used
+// to park on the channel with a NULL coroutine and segfault. The timeout is what makes the wait end.
+$channel = new Async\Channel(capacity: 1, noProducerTimeout: 50, hardTimeouts: true);
+
+try {
+    foreach ($channel as $value) {
+        echo "unexpected value: $value\n";
+    }
+
+    echo "loop ended silently\n";
+} catch (Async\ChannelException $exception) {
+    echo "caught: ", $exception->reason->name, "\n";
+}
+
+echo "done\n";
+?>
+--EXPECT--
+start
+caught: NO_PRODUCERS
+done

--- a/tests/channel/072-channel_foreach_deadlock_propagates.phpt
+++ b/tests/channel/072-channel_foreach_deadlock_propagates.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Channel: foreach propagates a deadlock instead of reporting a clean end of stream
+--FILE--
+<?php
+
+use function Async\spawn;
+use function Async\await;
+
+echo "start\n";
+
+// Only an explicit close() is a normal end of iteration. A deadlock arrives as the same
+// ChannelException, so swallowing it would silently turn a bug into "the stream ended, 0 items".
+$result = await(spawn(function () {
+    $channel = new Async\Channel(capacity: 2, noProducerTimeout: 100, hardTimeouts: true);
+
+    try {
+        foreach ($channel as $value) {
+            echo "unexpected value: $value\n";
+        }
+
+        return 'loop ended silently';
+    } catch (Async\ChannelException $exception) {
+        return 'propagated: ' . $exception->reason->name;
+    }
+}));
+
+echo $result, "\n";
+echo "done\n";
+?>
+--EXPECT--
+start
+propagated: NO_PRODUCERS
+done


### PR DESCRIPTION
Two bugs in the channel iterator, both found while validating the docs — not from the bug report.

## How they surfaced

The docs teach draining a channel like this:

```php
while (true) {
    try { $v = $ch->recv(); }
    catch (ChannelException) { break; }
    process($v);
}
```

That is a trap: `ChannelException` also carries deadlocks (`NO_PRODUCERS`, `NO_CONSUMERS`, `DEADLOCK`), so the loop silently turns a deadlock into "the stream ended, 0 items". `foreach` is the pattern that ought to be recommended instead — it *cannot* swallow a deadlock. Except it did not work.

## 1. Closing a channel while a consumer is parked in the loop

The ordinary producer/consumer shape:

```php
$consumer = spawn(fn() => array_map(..., iterator_to_array($channel)));   // foreach inside
$producer = spawn(function () use ($channel) {
    $channel->send('a');
    $channel->close();
});
```

`channel_iterator_move_forward()` parks in `channel_wait_for()` and is woken with a `ChannelException`. It stopped the loop (`valid = false`) but **left that exception pending**, so it escaped `foreach` uncaught — and surfaced against the **producer's** `close()`, which had done nothing wrong:

```
Fatal error: Uncaught Async\ChannelException: Channel is closed
Stack trace:
#0 Command line code(10): Async\Channel->close()
```

A channel closed *before* the loop starts takes an earlier branch (`ZEND_ASYNC_EVENT_IS_CLOSED`), which is why this stayed invisible.

An explicit `close()` is how an iteration ends, not a failure, so the exception is now consumed. Anything else — a deadlock, a disposal, a cancellation — is still left pending and propagates, which is the entire reason to prefer `foreach`.

## 2. Segfault when `foreach` is the first async operation

```php
$ch = new Async\Channel(1);
foreach ($ch as $v) {}     // SIGSEGV
```

```
#0 zend_async_resume_when (coroutine=0x0, …)   Zend/zend_async_API.c:1187
#1 channel_wait_for                            ext/async/channel.c:565
#2 channel_iterator_move_forward               ext/async/channel.c:798
#3 channel_iterator_rewind
#4 zend_fe_reset_iterator                      Zend/zend_execute.c:5403
```

`foreach` reaches `ce->get_iterator` straight from `FE_RESET`, bypassing `send()`/`recv()` and the `ENSURE_COROUTINE_CONTEXT` they run. With no main coroutine yet, `channel_wait_for()` suspended a `NULL` coroutine. `recv()` and `send()` at top level are fine — only the iterator path was unguarded.

The iterator now starts the scheduler, like every other blocking channel operation.

## Tests

- `070` — close during iteration. Fails on the unfixed build with the uncaught `ChannelException` above.
- `071` — `foreach` as the first async operation. **SIGSEGV** on the unfixed build.
- `072` — a deadlock must still propagate out of `foreach`. This one **passes either way, by design**: it is not a regression test but a guard, and would catch a fix that swallowed deadlocks along with clean closes.

Full `ext/async/tests`: `channel` 72/72, no new failures overall. The 3 that fail (`curl/063`, `curl/064`, `io/082`) fail identically on a pristine baseline.

## Noted separately, not addressed here

A channel deadlock leaks 152 bytes (`zend_objects.c:190`). Reproduces on a pristine baseline with a plain `recv()`, so it is independent of this change.