### PR TITLE
fix(scheduler): honour the ownership contract of ZEND_ASYNC_EXIT_EXCEPTION

### DIFF
--- a/scheduler.c
+++ b/scheduler.c
@@ -1403,6 +1403,10 @@ bool async_scheduler_main_coroutine_suspend(const bool with_bailout)
 	if (EG(exception) != NULL && exit_exception != NULL) {
 		if (UNEXPECTED(EG(exception) != exit_exception)) {
 			zend_exception_set_previous(EG(exception), exit_exception);
+		} else {
+			// Already the pending exception, so there is nobody to hand the global's reference to.
+			// The other two branches consume it; this one drops it.
+			OBJ_RELEASE(exit_exception);
 		}
 	} else if (exit_exception != NULL) {
 		async_rethrow_exception(exit_exception);
@@ -2050,10 +2054,15 @@ to_bailout_all_coroutines:
 		if (UNEXPECTED(EG(exception) != exit_exception)) {
 			zend_exception_set_previous(EG(exception), exit_exception);
 		}
-		exit_exception = EG(exception);
-		GC_ADDREF(exit_exception);
+
+		// ZEND_ASYNC_EXIT_EXCEPTION owns its reference: the new exit exception goes into the global, not
+		// into the local, otherwise the added reference has no owner.
+		ZEND_ASYNC_EXIT_EXCEPTION = EG(exception);
+		GC_ADDREF(EG(exception));
 		zend_clear_exception();
 	} else if (exit_exception != NULL) {
+		// The rethrow moves the global's reference into EG(exception), so the global must let it go.
+		ZEND_ASYNC_EXIT_EXCEPTION = NULL;
 		async_rethrow_exception(exit_exception);
 	}
 


### PR DESCRIPTION
Found while chasing the 152-byte leak that every deadlock produces. **It does not fix that leak** (see the end) — but it fixes two genuine violations of the ownership contract found on the way, and it removes a latent segfault.

## The contract

`ZEND_ASYNC_EXIT_EXCEPTION` owns its reference: a **copy** into it takes a `+1`, a **move** out of it must clear it. `fiber_entry()` broke both halves.

## 1. A reference with no owner

```c
	if (EG(exception) != NULL && exit_exception != NULL) {
		...
		exit_exception = EG(exception);     // <- the LOCAL, not the global
		GC_ADDREF(exit_exception);          // <- +1 whose owner is a local about to die
		zend_clear_exception();
	}
```

The intent is plainly "the exit exception is now EG's exception" — and `graceful_shutdown()` / `finally_shutdown()` do exactly that, by assigning to `ZEND_ASYNC_EXIT_EXCEPTION`. Here it assigns to the local, so the `GC_ADDREF` produces a reference nobody owns, and the global keeps pointing at the *previous* object.

## 2. A move dressed as a copy

```c
	} else if (exit_exception != NULL) {
		async_rethrow_exception(exit_exception);   // moves the reference into EG(exception)
	}
```

The reference is handed to `EG(exception)`, but `ZEND_ASYNC_EXIT_EXCEPTION` is left pointing at the object it no longer owns. Measured on a deadlock:

```
resolve_deadlocks: NEW DeadlockError handle=4 rc=1 (global=nil)   <- the global owns the only ref
fiber_entry tail:  exit=h4 rc=1   EG=(nil)                        <- else-if runs, the ref moves to EG
```

After that the global is a dangling, non-owning pointer.

## 3. The exit point, and why it used to segfault

`async_scheduler_main_coroutine_suspend()` takes the global's reference and both of its branches consume it — except when the exit exception *is* the pending one, where it had nobody to hand it to and silently dropped it. It now releases it.

That release is only safe **because** the two bugs above are fixed. Against the old, inconsistent ownership it freed the object out from under `EG(exception)`: I tried exactly that first, and it segfaulted `edge_cases/001, 002, 003, 010`. Those four tests are what caught it, and they pass now.

## Tests

Full `ext/async/tests`: **1116 passed**, no new failures. The 3 that fail (`curl/063`, `curl/064`, `io/082`) fail identically on a pristine baseline. `edge_cases` 14/14.

## Still open: the leak itself

Every deadlock — channel or plain mutual `await`, caught or uncaught — leaks one 152-byte object:

```
[LEAKOBJ] class=Async\DeadlockError rc=2 handle=4  EG(exception)=<same object>  previous=none
```

At the leak report `EG(exception)` **still points at it**, with refcount 2. `shutdown_executor()` never releases `EG(exception)` — PHP assumes the VM always consumes it — so anything left there at the end of a request leaks by construction. `zend_exception_error()` (`main.c:2691`) *does* take EG's reference and clear it (the "Uncaught Async\DeadlockError" fatal is printed, so it ran), yet by shutdown EG is armed with the same object again and the refcount is 2.

Something re-arms `EG(exception)` after the fatal has already consumed it. I did not find it, and I would rather leave it open than guess — the last guess cost four segfaulting tests.