### PR TITLE
feat(context): get()/getLocal() throw on a missing key instead of returning null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`Context::get()` and `getLocal()` now throw `Async\ContextException` when the key is missing, instead of returning `null`.** They were exact duplicates of `find()`/`findLocal()`, which made them pointless. `get()` is the mandatory-value form; `find()` remains the one that answers `null`.
+
 ### Fixed
 - **`foreach` over a `Channel` broke on the ordinary producer/consumer pattern.** Closing a channel while a consumer was parked in the loop left the wake-up `ChannelException` pending, so it escaped `foreach` uncaught — and surfaced against the producer's `close()`, which had done nothing wrong. An explicit `close()` now ends the iteration cleanly, while a deadlock or a disposal still propagates.
 

--- a/async.c
+++ b/async.c
@@ -1779,8 +1779,9 @@ ZEND_MINIT_FUNCTION(async)
 	async_register_timeout_ce();
 	async_register_scope_ce();
 	async_register_coroutine_ce();
-	async_register_context_ce();
+	// Must follow the exceptions: ContextException derives from AsyncException.
 	async_register_exceptions_ce();
+	async_register_context_ce();
 	async_register_channel_ce();
 	async_register_thread_channel_ce();
 	async_register_thread_pool_ce();

--- a/context.c
+++ b/context.c
@@ -17,6 +17,7 @@
 
 #include "exceptions.h"
 #include "context_arginfo.h"
+#include "zend_exceptions.h"
 
 //////////////////////////////////////////////////////////////////////
 /// Context API Implementation

--- a/context.c
+++ b/context.c
@@ -197,6 +197,7 @@ void async_context_dispose(async_context_t *context)
 //////////////////////////////////////////////////////////////////////
 
 zend_class_entry *async_ce_context = NULL;
+zend_class_entry *async_ce_context_exception = NULL;
 
 #define METHOD(name) ZEND_METHOD(Async_Context, name)
 #define ZEND_OBJECT_TO_CONTEXT(obj) ((async_context_t *) ((char *) (obj) - (obj)->handlers->offset))
@@ -209,6 +210,19 @@ zend_class_entry *async_ce_context = NULL;
 			RETURN_THROWS(); \
 		} \
 	} while (0)
+
+/**
+ * get()/getLocal() are the mandatory-value forms; find()/findLocal() are the ones that answer null.
+ */
+static void context_throw_missing_key(const zval *key)
+{
+	if (Z_TYPE_P(key) == IS_STRING) {
+		zend_throw_exception_ex(async_ce_context_exception, 0, "Context key \"%s\" not found", Z_STRVAL_P(key));
+	} else {
+		zend_throw_exception_ex(
+				async_ce_context_exception, 0, "Context key of type %s not found", ZSTR_VAL(Z_OBJCE_P(key)->name));
+	}
+}
 
 METHOD(find)
 {
@@ -239,7 +253,8 @@ METHOD(get)
 		return;
 	}
 
-	RETURN_NULL();
+	context_throw_missing_key(key);
+	RETURN_THROWS();
 }
 
 METHOD(has)
@@ -283,7 +298,8 @@ METHOD(getLocal)
 		return;
 	}
 
-	RETURN_NULL();
+	context_throw_missing_key(key);
+	RETURN_THROWS();
 }
 
 METHOD(hasLocal)
@@ -362,6 +378,7 @@ static void context_free(zend_object *object)
 
 void async_register_context_ce(void)
 {
+	async_ce_context_exception = register_class_Async_ContextException(async_ce_async_exception);
 	async_ce_context = register_class_Async_Context();
 
 	async_ce_context->create_object = context_object_create;

--- a/context.h
+++ b/context.h
@@ -42,6 +42,7 @@ void async_context_dispose(async_context_t *context);
 
 // Class entry
 PHP_ASYNC_API extern zend_class_entry *async_ce_context;
+PHP_ASYNC_API extern zend_class_entry *async_ce_context_exception;
 void async_register_context_ce(void);
 
 

--- a/context.stub.php
+++ b/context.stub.php
@@ -5,6 +5,11 @@
 namespace Async;
 
 /**
+ * Thrown when a mandatory Context key is missing.
+ */
+class ContextException extends AsyncException {}
+
+/**
  * @strict-properties
  * @not-serializable
  */
@@ -12,11 +17,17 @@ final class Context
 {
     /**
      * Find a value by key in the current or parent Context.
+     *
+     * Returns null when the key is absent. Use get() when the value is mandatory.
      */
     public function find(string|object $key): mixed {}
 
     /**
-     * Get a value by key in the current Context.
+     * Get a value by key in the current or parent Context.
+     *
+     * Unlike find(), a missing key is an error rather than a null.
+     *
+     * @throws ContextException If the key is not found at any level.
      */
     public function get(string|object $key): mixed {}
 
@@ -27,11 +38,17 @@ final class Context
 
     /**
      * Find a value by key only in the local Context.
+     *
+     * Returns null when the key is absent. Use getLocal() when the value is mandatory.
      */
     public function findLocal(string|object $key): mixed {}
 
     /**
      * Get a value by key only in the local Context.
+     *
+     * Unlike findLocal(), a missing key is an error rather than a null.
+     *
+     * @throws ContextException If the key is not found in the local Context.
      */
     public function getLocal(string|object $key): mixed {}
 

--- a/context_arginfo.h
+++ b/context_arginfo.h
@@ -1,14 +1,14 @@
-/* This is a generated file, edit the .stub.php file instead.
- * Stub hash: bb8f3ff840be0001815129aa778f2c91b5701873 */
+/* This is a generated file, edit context.stub.php instead.
+ * Stub hash: 9cee158f24f5c73feaca9c17d8b82fba15e506de */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Async_Context_find, 0, 1, IS_MIXED, 0)
-ZEND_ARG_TYPE_MASK(0, key, MAY_BE_STRING | MAY_BE_OBJECT, NULL)
+	ZEND_ARG_TYPE_MASK(0, key, MAY_BE_STRING|MAY_BE_OBJECT, NULL)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Async_Context_get arginfo_class_Async_Context_find
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Async_Context_has, 0, 1, _IS_BOOL, 0)
-ZEND_ARG_TYPE_MASK(0, key, MAY_BE_STRING | MAY_BE_OBJECT, NULL)
+	ZEND_ARG_TYPE_MASK(0, key, MAY_BE_STRING|MAY_BE_OBJECT, NULL)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Async_Context_findLocal arginfo_class_Async_Context_find
@@ -18,13 +18,13 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_Async_Context_hasLocal arginfo_class_Async_Context_has
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Async_Context_set, 0, 2, Async\\Context, 0)
-ZEND_ARG_TYPE_MASK(0, key, MAY_BE_STRING | MAY_BE_OBJECT, NULL)
-ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
-ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, replace, _IS_BOOL, 0, "false")
+	ZEND_ARG_TYPE_MASK(0, key, MAY_BE_STRING|MAY_BE_OBJECT, NULL)
+	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, replace, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Async_Context_unset, 0, 1, Async\\Context, 0)
-ZEND_ARG_TYPE_MASK(0, key, MAY_BE_STRING | MAY_BE_OBJECT, NULL)
+	ZEND_ARG_TYPE_MASK(0, key, MAY_BE_STRING|MAY_BE_OBJECT, NULL)
 ZEND_END_ARG_INFO()
 
 ZEND_METHOD(Async_Context, find);
@@ -37,24 +37,33 @@ ZEND_METHOD(Async_Context, set);
 ZEND_METHOD(Async_Context, unset);
 
 static const zend_function_entry class_Async_Context_methods[] = {
-	ZEND_ME(Async_Context, find, arginfo_class_Async_Context_find, ZEND_ACC_PUBLIC) ZEND_ME(
-			Async_Context, get, arginfo_class_Async_Context_get, ZEND_ACC_PUBLIC)
-			ZEND_ME(Async_Context, has, arginfo_class_Async_Context_has, ZEND_ACC_PUBLIC) ZEND_ME(
-					Async_Context, findLocal, arginfo_class_Async_Context_findLocal, ZEND_ACC_PUBLIC)
-					ZEND_ME(Async_Context, getLocal, arginfo_class_Async_Context_getLocal, ZEND_ACC_PUBLIC) ZEND_ME(
-							Async_Context, hasLocal, arginfo_class_Async_Context_hasLocal, ZEND_ACC_PUBLIC)
-							ZEND_ME(Async_Context, set, arginfo_class_Async_Context_set, ZEND_ACC_PUBLIC)
-									ZEND_ME(Async_Context, unset, arginfo_class_Async_Context_unset, ZEND_ACC_PUBLIC)
-											ZEND_FE_END
+	ZEND_ME(Async_Context, find, arginfo_class_Async_Context_find, ZEND_ACC_PUBLIC)
+	ZEND_ME(Async_Context, get, arginfo_class_Async_Context_get, ZEND_ACC_PUBLIC)
+	ZEND_ME(Async_Context, has, arginfo_class_Async_Context_has, ZEND_ACC_PUBLIC)
+	ZEND_ME(Async_Context, findLocal, arginfo_class_Async_Context_findLocal, ZEND_ACC_PUBLIC)
+	ZEND_ME(Async_Context, getLocal, arginfo_class_Async_Context_getLocal, ZEND_ACC_PUBLIC)
+	ZEND_ME(Async_Context, hasLocal, arginfo_class_Async_Context_hasLocal, ZEND_ACC_PUBLIC)
+	ZEND_ME(Async_Context, set, arginfo_class_Async_Context_set, ZEND_ACC_PUBLIC)
+	ZEND_ME(Async_Context, unset, arginfo_class_Async_Context_unset, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
 };
+
+static zend_class_entry *register_class_Async_ContextException(zend_class_entry *class_entry_Async_AsyncException)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "Async", "ContextException", NULL);
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Async_AsyncException, 0);
+
+	return class_entry;
+}
 
 static zend_class_entry *register_class_Async_Context(void)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Async", "Context", class_Async_Context_methods);
-	class_entry = zend_register_internal_class_with_flags(
-			&ce, NULL, ZEND_ACC_FINAL | ZEND_ACC_NO_DYNAMIC_PROPERTIES | ZEND_ACC_NOT_SERIALIZABLE);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_NOT_SERIALIZABLE);
 
 	return class_entry;
 }

--- a/fuzzy-tests/_harness/Steps.php
+++ b/fuzzy-tests/_harness/Steps.php
@@ -3526,8 +3526,12 @@ final class StandardSteps {
                         && $cc->get($key) === $value
                         && $cc->has($key) === true;
                     $ctx->inc($inheritOk ? "inherit_hit_$coro" : "inherit_miss_$coro");
+                    // getLocal() throws on a missing key; findLocal() is the null-returning form.
+                    $getLocalThrew = false;
+                    try { $cc->getLocal($key); }
+                    catch (\Async\ContextException $e) { $getLocalThrew = true; }
                     $localAbsent = $cc->findLocal($key) === null
-                        && $cc->getLocal($key) === null
+                        && $getLocalThrew
                         && $cc->hasLocal($key) === false;
                     $ctx->inc($localAbsent ? "local_absent_$coro" : "local_present_$coro");
                 });
@@ -3576,7 +3580,11 @@ final class StandardSteps {
                         $cc->unset($key);
                         if ($cc->has($key) !== false) $pass = false;
                         if ($cc->hasLocal($key) !== false) $pass = false;
-                        if ($cc->get($key) !== null) $pass = false;
+                        // After unset the key is gone, so get() must throw rather than answer null.
+                        $getThrew = false;
+                        try { $cc->get($key); }
+                        catch (\Async\ContextException $e) { $getThrew = true; }
+                        if (!$getThrew) $pass = false;
                     } catch (\Throwable $e) {
                         $pass = false;
                     }

--- a/tests/context/002-context_inheritance.phpt
+++ b/tests/context/002-context_inheritance.phpt
@@ -7,6 +7,15 @@ use function Async\spawn;
 use function Async\current_context;
 use function Async\await;
 
+function get_local_or_throws(\Async\Context $context, string $key): string
+{
+    try {
+        return (string) $context->getLocal($key);
+    } catch (\Async\ContextException) {
+        return 'throws';
+    }
+}
+
 echo "start\n";
 
 // Create parent scope
@@ -53,9 +62,9 @@ $child_coroutine = $child_scope->spawn(function() {
     echo "findLocal parent_key: " . ($context->findLocal('parent_key') ?: 'null') . "\n";
     echo "findLocal shared_key: " . ($context->findLocal('shared_key') ?: 'null') . "\n";
     
-    // Test getLocal() - should NOT find parent values
-    echo "getLocal parent_key: " . ($context->getLocal('parent_key') ?: 'null') . "\n";
-    echo "getLocal shared_key: " . ($context->getLocal('shared_key') ?: 'null') . "\n";
+    // Test getLocal() - should NOT find parent values, and a miss is an error rather than a null
+    echo "getLocal parent_key: " . get_local_or_throws($context, 'parent_key') . "\n";
+    echo "getLocal shared_key: " . get_local_or_throws($context, 'shared_key') . "\n";
     
     // Test hasLocal() - should NOT find parent values
     echo "hasLocal parent_key: " . ($context->hasLocal('parent_key') ? 'true' : 'false') . "\n";
@@ -100,8 +109,8 @@ has parent_key: true
 has shared_key: true
 findLocal parent_key: null
 findLocal shared_key: null
-getLocal parent_key: null
-getLocal shared_key: null
+getLocal parent_key: throws
+getLocal shared_key: throws
 hasLocal parent_key: false
 hasLocal shared_key: false
 child context values set

--- a/tests/context/008-context_get_missing.phpt
+++ b/tests/context/008-context_get_missing.phpt
@@ -1,21 +1,29 @@
 --TEST--
-Context: get() returns null for missing keys
+Context: get() throws for missing keys
 --FILE--
 <?php
 
-use Async\Context;
 use function Async\current_context;
 
-// Covers context.c METHOD(get) L242 RETURN_NULL fallback when
-// async_context_find() reports the key as missing.
+// get() is the mandatory-value form: a missing key is an error, not a null.
+// find() is the one that answers null.
 
 $ctx = current_context();
 $ctx->set('present', 'value');
 
 var_dump($ctx->get('present'));
-var_dump($ctx->get('missing'));
+
+try {
+    $ctx->get('missing');
+    echo "NOT THROWN\n";
+} catch (Async\ContextException $exception) {
+    echo $exception->getMessage(), "\n";
+}
+
+var_dump($ctx->find('missing'));
 
 ?>
 --EXPECT--
 string(5) "value"
+Context key "missing" not found
 NULL

--- a/tests/context/011-context_get_throws_on_missing_key.phpt
+++ b/tests/context/011-context_get_throws_on_missing_key.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Context: get()/getLocal() throw on a missing key, find()/findLocal() answer null
+--FILE--
+<?php
+
+use function Async\current_context;
+
+// get() used to be an exact duplicate of find(): both walked the parents and both answered
+// null. It is the mandatory-value form -- a missing key is an error, not a null.
+$context = current_context();
+$context->set('present', 'V');
+
+echo "find(missing):      ", var_export($context->find('missing'), true), "\n";
+echo "findLocal(missing): ", var_export($context->findLocal('missing'), true), "\n";
+
+try {
+    $context->get('missing');
+    echo "get(missing): NOT THROWN\n";
+} catch (Async\ContextException $exception) {
+    echo "get(missing):      ", $exception->getMessage(), "\n";
+}
+
+try {
+    $context->getLocal('missing');
+    echo "getLocal(missing): NOT THROWN\n";
+} catch (Async\ContextException $exception) {
+    echo "getLocal(missing): ", $exception->getMessage(), "\n";
+}
+
+echo "get(present):       ", var_export($context->get('present'), true), "\n";
+echo "extends AsyncException: ", var_export(is_subclass_of(Async\ContextException::class, Async\AsyncException::class), true), "\n";
+?>
+--EXPECT--
+find(missing):      NULL
+findLocal(missing): NULL
+get(missing):      Context key "missing" not found
+getLocal(missing): Context key "missing" not found
+get(present):       'V'
+extends AsyncException: true

--- a/tests/context/012-context_get_object_key_and_inheritance.phpt
+++ b/tests/context/012-context_get_object_key_and_inheritance.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Context: get() reaches parent Scopes, and reports an object key by class
+--FILE--
+<?php
+
+use function Async\current_context;
+use function Async\await;
+
+$context = current_context();
+$context->set('inherited', 'V');
+
+// get() searches the parent Scopes, exactly like find() -- only the miss differs.
+$scope = Async\Scope::inherit();
+echo "get from a child Scope: ", var_export(await($scope->spawn(fn() => current_context()->get('inherited'))), true), "\n";
+
+// getLocal() stops at the local Context, so the inherited key is a miss there.
+echo "getLocal from a child Scope: ", await($scope->spawn(function () {
+    try {
+        current_context()->getLocal('inherited');
+        return 'NOT THROWN';
+    } catch (Async\ContextException $exception) {
+        return $exception->getMessage();
+    }
+})), "\n";
+
+$key = new stdClass();
+
+try {
+    $context->get($key);
+    echo "object key: NOT THROWN\n";
+} catch (Async\ContextException $exception) {
+    echo "object key: ", $exception->getMessage(), "\n";
+}
+
+$context->set($key, 'OBJ');
+echo "object key, present: ", var_export($context->get($key), true), "\n";
+?>
+--EXPECT--
+get from a child Scope: 'V'
+getLocal from a child Scope: Context key "inherited" not found
+object key: Context key of type stdClass not found
+object key, present: 'OBJ'


### PR DESCRIPTION
## The problem

`get()` was an **exact duplicate** of `find()`, and `getLocal()` of `findLocal()`. Four methods, two behaviours:

```
find(parentKey)      'P'      get(parentKey)       'P'
findLocal(parentKey) NULL     getLocal(parentKey)  NULL
                              get(missing)         NULL
```

Both walked the parent Scopes; both answered `null` on a miss. Half of the API had no reason to exist.

And **three sources described three different things**:

| Source | Claim |
|---|---|
| The site docs | *"Unlike `find()`, this method throws if the key is not found at any level. Use `get()` when the value is mandatory."* — and `@throws Async\ContextException` |
| The stub | *"Get a value by key in the current Context"* — i.e. no parent lookup |
| The code | Identical to `find()`. Returns `null`. `ContextException` does not exist. |

The site was describing the useful contract — the standard `find` / `get` split (cf. PSR-11) — and the code simply never implemented it.

## The change

- `find()` / `findLocal()` — the **optional-value** forms. Unchanged: they answer `null`.
- `get()` / `getLocal()` — the **mandatory-value** forms. A missing key now raises `Async\ContextException`, the class the docs already referred to.

```php
$context->find('missing');      // null
$context->get('missing');       // Async\ContextException: Context key "missing" not found
$context->get($objectKey);      // Async\ContextException: Context key of type Foo not found
```

Parent lookup is untouched — `get()` still reaches inherited Scopes, exactly like `find()`. Only the miss differs.

## Registration order

`async_register_context_ce()` ran **before** `async_register_exceptions_ce()`, so `ContextException` was handed a `NULL` parent and tripped `Exceptions must implement Throwable`. Context registration now follows the exceptions, as Channel's already does.

## BC break — deliberate, and two tests updated rather than worked around

- **`008-context_get_missing.phpt`** was literally named *"Context: get() returns null for missing keys"*. It pinned the behaviour we are calling a bug. It now covers the throw, and keeps a `find()` call so the null half of the contract stays pinned.
- **`002-context_inheritance.phpt`** used `getLocal()` to show that a local lookup does not reach the parent. That intent is unchanged — under the new contract it is expressed by the throw rather than by a `null`. `findLocal()` still pins the null.

## Tests

- New `011` — `get()`/`getLocal()` throw, `find()`/`findLocal()` answer `null`, present keys still return, `ContextException extends AsyncException`.
- New `012` — `get()` reaches parent Scopes; `getLocal()` does not; object keys are reported by class name.
- `context` 12/12. Full `ext/async/tests`: no new failures — the 3 that fail (`curl/063`, `curl/064`, `io/082`) fail identically on a pristine baseline.

The 36 mentions of `ContextException` in the docs were left alone on purpose while this was pending; they are now correct.