### PR TITLE
test(edge_cases): a caught deadlock cancellation still terminates with DeadlockError

### DIFF
--- a/tests/edge_cases/015-deadlock-caught-still-terminates.phpt
+++ b/tests/edge_cases/015-deadlock-caught-still-terminates.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Deadlock: catching the cancellation does not suppress the terminal DeadlockError
+--INI--
+async.debug_deadlock=0
+--FILE--
+<?php
+
+// A deadlock cancels the parked coroutines with a catchable AsyncCancellation, so the recv()
+// below can be caught and the script keeps running. The deadlock itself is terminal, though:
+// once the body finishes, the scheduler still raises DeadlockError to end the process.
+
+$channel = new Async\Channel(1);
+
+try {
+    $channel->recv();
+} catch (Async\AsyncCancellation $exception) {
+    echo "caught: ", $exception::class, "\n";
+}
+
+echo "after catch\n";
+?>
+--EXPECTF--
+caught: Async\AsyncCancellation
+after catch
+
+Fatal error: Uncaught Async\DeadlockError: Deadlock detected: no active coroutines, %d coroutines in waiting in %s:%d
+Stack trace:
+#0 %s(%d): Async\Channel->recv()
+#1 {main}
+  thrown in %s on line %d

--- a/tests/edge_cases/015-deadlock-caught-still-terminates.phpt
+++ b/tests/edge_cases/015-deadlock-caught-still-terminates.phpt
@@ -25,6 +25,5 @@ after catch
 
 Fatal error: Uncaught Async\DeadlockError: Deadlock detected: no active coroutines, %d coroutines in waiting in %s:%d
 Stack trace:
-#0 %s(%d): Async\Channel->recv()
-#1 {main}
+%A
   thrown in %s on line %d


### PR DESCRIPTION
Pins a two-part contract that was uncovered, and documents the behaviour behind a debug-only `php -r` report.

## What it pins

A deadlock cancels the parked coroutines with a **catchable** `AsyncCancellation`, so this is legal and the script keeps running:

```php
$channel = new Async\Channel(1);
try {
    $channel->recv();
} catch (Async\AsyncCancellation $e) {
    echo "caught: ", $e::class, "\n";
}
echo "after catch\n";      // <- this runs
```

But the deadlock is a **terminal** condition. Once the body finishes, the scheduler still raises `DeadlockError` to end the process:

```
caught: Async\AsyncCancellation
after catch

Fatal error: Uncaught Async\DeadlockError: Deadlock detected: ...
```

The existing `002-deadlock-with-catch` catches *inside* the deadlocked coroutines; this one catches at the top level and shows that catching does not suppress the terminal error. `async.debug_deadlock=0` in `--INI--` keeps the diagnostic dump out of the captured output.

## Background — why there is no leak test

This came out of chasing a `Freeing ... 152 bytes` report from the Zend MM leak tracker after a deadlock. The full picture, established by measurement:

- **Not a real leak.** `valgrind --leak-check=full` (with `USE_ZEND_ALLOC=0`): `0 bytes lost, 0 errors`. The block is freed at MM shutdown.
- **`php -r` only.** File execution is clean; the report appears solely via the CLI `-r` eval entry. Deterministic, 10/10 each way.
- **Root:** in file mode `php_execute_script` consumes the terminal `DeadlockError` left in `EG(exception)` (the "Uncaught" fatal) and frees it; the `-r` path leaves it for MM shutdown to clean up.

A `.phpt` cannot reproduce the `-r`-only report — `run-tests.php` always executes a file — so this test captures the observable *behaviour*, not the report. The report itself is tracked separately.