### PR TITLE
fix(future): map()/catch()/finally() keep the chain when the source is a temporary (#193)

### DIFF
--- a/future.c
+++ b/future.c
@@ -497,6 +497,13 @@ static bool zend_future_resolve(zend_async_event_t *event, void *iterator)
 	// Notify resolve_callbacks (map/catch/finally chains) with iterator
 	zend_async_callbacks_vector_notify(&future->resolve_callbacks, event, iterator);
 
+	// The chain has been handed to the mapper iterator (which now holds its own ref on each source),
+	// so dispose the subscriptions now instead of at future teardown. Their dispose drops the strong
+	// ref on the source Future, breaking the source <-> event cycle that the GC cannot see -- without
+	// this a temporary source would be kept alive to end of request. A completed future takes no new
+	// resolve_callbacks (map/catch/finally then spawn immediately), so freeing here loses nothing.
+	zend_async_callbacks_vector_free(&future->resolve_callbacks, event);
+
 	if (ZEND_ASYNC_EVENT_IS_EXCEPTION_HANDLED(event)) {
 		ZEND_FUTURE_SET_EXCEPTION_CAUGHT(future);
 	}
@@ -1609,7 +1616,8 @@ static void async_future_callback_dispose(zend_async_event_callback_t *callback,
 	async_future_callback_t *future_callback = (async_future_callback_t *) callback;
 
 	if (future_callback->future_obj != NULL) {
-		// No OBJ_RELEASE(&future_callback->future_obj->std);
+		// Release the strong ref taken in async_future_create_mapper().
+		OBJ_RELEASE(&future_callback->future_obj->std);
 		future_callback->future_obj = NULL;
 	}
 
@@ -1735,8 +1743,11 @@ static void async_future_create_mapper(INTERNAL_FUNCTION_PARAMETERS, async_futur
 		callback->base.dispose = async_future_callback_dispose;
 		callback->future_obj = source;
 		callback->scope = ZEND_ASYNC_CURRENT_SCOPE;
-		// We do not increment the object's reference count because this is a "weak reference".
-		// No GC_ADDREF(&source->std);
+		// Strong ref: the child futures live in source->child_futures, so source must outlive the
+		// subscription. Without it a temporary source (e.g. (new Future($s))->map(...)) is freed
+		// right after the call, its child table is destroyed, and the chain is silently lost.
+		// Released in async_future_callback_dispose().
+		GC_ADDREF(&source->std);
 
 		// Add to resolve_callbacks (not regular callbacks) for chain processing
 		if (UNEXPECTED(!zend_async_callbacks_vector_push(&source_future->resolve_callbacks, &callback->base))) {

--- a/tests/future/038-map_temporary_source.phpt
+++ b/tests/future/038-map_temporary_source.phpt
@@ -1,0 +1,53 @@
+--TEST--
+Future: map()/catch()/finally() on a temporary source resolve the derived Future (issue #193)
+--FILE--
+<?php
+
+use function Async\await;
+
+// The child futures live in source->child_futures, owned by the source PHP object. When the source
+// is a one-liner temporary (or unset() right after), it used to be freed while its state was still
+// pending, dropping the whole chain -- the derived Future never resolved and the script deadlocked.
+
+// map()
+$s = new Async\FutureState();
+$f = (new Async\Future($s))->map(fn($v) => $v * 2);
+$s->complete(21);
+echo "map: ", $f->await(), "\n";
+
+// catch()
+$s = new Async\FutureState();
+$f = (new Async\Future($s))->catch(fn($e) => "caught:" . $e->getMessage());
+$s->error(new Exception("boom"));
+echo "catch: ", $f->await(), "\n";
+
+// finally()
+$s = new Async\FutureState();
+$ran = false;
+$f = (new Async\Future($s))->finally(function () use (&$ran) { $ran = true; });
+$s->complete(7);
+echo "finally: ", $f->await(), " ran=", $ran ? "y" : "n", "\n";
+
+// unset() the source right after deriving
+$s = new Async\FutureState();
+$base = new Async\Future($s);
+$f = $base->map(fn($v) => $v + 1);
+unset($base);
+$s->complete(10);
+echo "unset: ", $f->await(), "\n";
+
+// chained on a temporary
+$s = new Async\FutureState();
+$f = (new Async\Future($s))->map(fn($v) => $v * 2)->map(fn($v) => $v + 1);
+$s->complete(5);
+echo "chain: ", $f->await(), "\n";
+
+echo "done\n";
+?>
+--EXPECT--
+map: 42
+catch: caught:boom
+finally: 7 ran=y
+unset: 11
+chain: 11
+done


### PR DESCRIPTION
Fixes #193.

## Symptom

The idiomatic one-liner deadlocks:

```php
$s = new Async\FutureState();
$f = (new Async\Future($s))->map(fn($v) => $v * 2);   // source Future is a temporary
$s->complete(21);
echo $f->await();                                      // never returns -> DeadlockError
```

Holding the source (`$base = new Future($s); $base->map(...)`) works; `unset($base)` after the call reproduces it. Affects `map()`, `catch()`, `finally()` — every method that derives a new Future — and only when the source state is **pending** at the call.

## Cause

The derived futures live in `source->child_futures`, a table owned by the **source PHP object**. The subscription on `source_future->resolve_callbacks` held the source as a **weak** reference (`// No GC_ADDREF`). When the source is a temporary and is released, `free_obj` destroys the child table, while the `zend_future_t` lives on (the `FutureState` owns it) — so when it finally completes there is no longer anyone to run the mapper, and the child Future the caller holds stays pending forever.

## Fix

1. The subscription takes a **strong** ref on the source (released in `async_future_callback_dispose`), so the source outlives it.

2. That strong ref plus `source->event` forms a `source ↔ event` cycle the cycle GC cannot see — the ref lives in a C callback struct, not a traversable zval — so a temporary source would be kept alive to end of request. To break it, `resolve_callbacks` are disposed **as soon as they fire** in `zend_future_resolve`, right after the notify that hands each chain to its mapper iterator. The iterator takes its own ref on the source (`future_iterator_create` → `Z_ADDREF`), so the source stays alive for processing, and the cycle is broken at completion. A completed future never takes new `resolve_callbacks` (map/catch/finally on a completed source spawn immediately), so freeing there loses nothing. The teardown free becomes a no-op (`vector_free` nulls its data).

## Verified

`tests/future/038-map_temporary_source.phpt` — map/catch/finally/unset/chain on a temporary source. **Deadlocks on the unfixed build; passes with no leaks on the fixed one.**

- `ext/async/tests/future` + `await` + `remote_future`: 146/146.
- Full `ext/async/tests`: no new failures (the 3 curl/io reds are a local checkout-path artifact, green on CI).
- `ext/async/fuzzy-tests/_generated`: 724/724.
- No memory leaks in any variant (the whole point of step 2).