### PR TITLE
fix(reactor): refresh loop clock when arming relative userland timeouts (#185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`Context::get()` and `getLocal()` now throw `Async\ContextException` when the key is missing, instead of returning `null`.** They were exact duplicates of `find()`/`findLocal()`, which made them pointless. `get()` is the mandatory-value form; `find()` remains the one that answers `null`.
 
 ### Fixed
+- **`delay()`/`timeout()` fired almost instantly after synchronous CPU work in the same coroutine (#185).** libuv computes a timer's deadline from `loop->time`, its clock cached once per loop iteration. A coroutine that burned CPU without yielding for longer than the timeout it then armed left that clock stale, so the deadline was already in the past and the timer fired at once — silently skipping the wait. Relative userland timeouts now refresh the reactor clock at arm time; hot per-I/O deadline timers are unaffected.
+
 - **`foreach` over a `Channel` broke on the ordinary producer/consumer pattern.** Closing a channel while a consumer was parked in the loop left the wake-up `ChannelException` pending, so it escaped `foreach` uncaught — and surfaced against the producer's `close()`, which had done nothing wrong. An explicit `close()` now ends the iteration cleanly, while a deadlock or a disposal still propagates.
 
 - **Segfault: `foreach` over a `Channel` as the first async operation.** The loop reaches the iterator straight from `FE_RESET`, bypassing the guard `send()`/`recv()` run, so with no main coroutine yet it parked a `NULL` coroutine. It now starts the scheduler like every other blocking channel operation.

--- a/async.c
+++ b/async.c
@@ -1657,6 +1657,10 @@ static zend_object *async_timeout_create(const zend_ulong ms, const bool is_peri
 		return NULL;
 	}
 
+	// A timeout() may be armed mid-tick after synchronous CPU work; refresh the
+	// reactor clock at arm time so its deadline is not computed from a stale clock.
+	ZEND_ASYNC_TIMER_SET_REFRESH_CLOCK((zend_async_timer_event_t *) event);
+
 	ZEND_ASYNC_EVENT_REF_SET(object, offsetof(async_timeout_object_t, std), (zend_async_timer_event_t *) event);
 	// A special flag is set to indicate that the event will contain a reference to a Zend object.
 	ZEND_ASYNC_EVENT_WITH_OBJECT_REF(event);

--- a/libuv_reactor.c
+++ b/libuv_reactor.c
@@ -1066,6 +1066,13 @@ static bool libuv_timer_start(zend_async_event_t *event)
 
 	async_timer_event_t *timer = (async_timer_event_t *) (event);
 
+	// Relative userland timeouts (delay()/timeout()) may be armed mid-tick after
+	// synchronous CPU work left loop->time stale; refresh it so uv_timer_start does
+	// not compute an already-past deadline. I/O deadline timers skip this refresh.
+	if (ZEND_ASYNC_TIMER_IS_REFRESH_CLOCK(&timer->event)) {
+		uv_update_time(UVLOOP);
+	}
+
 	const int error = uv_timer_start(&timer->uv_handle,
 									 on_timer_event,
 									 timer->event.timeout,

--- a/tests/sleep/007-delay_after_cpu_burn.phpt
+++ b/tests/sleep/007-delay_after_cpu_burn.phpt
@@ -1,0 +1,55 @@
+--TEST--
+Async\delay() after synchronous CPU work still waits (#185, stale libuv loop time)
+--FILE--
+<?php
+
+use function Async\spawn;
+use function Async\await;
+use function Async\delay;
+use Async\Scope;
+
+// #185: a coroutine that burns CPU without yielding for longer than the timeout
+// it then arms left libuv's cached loop->time stale, so delay() computed an
+// already-past deadline and returned almost instantly instead of waiting. The
+// reactor clock is now refreshed when a relative userland timeout is armed.
+//
+// The second coroutine's delay(50) is what exposes the bug: with a single timer
+// libuv's relative poll timeout hides the staleness, but a concurrent timer makes
+// the loop re-check the burning coroutine's timer against an already-advanced
+// clock and fire it early.
+//
+// Timers only ever fire late, never early, so the lower bound cannot flake:
+// with the bug delay(150) returns in ~0ms, with the fix it waits the full ~150ms.
+
+function burn_cpu_ms(float $ms): void {
+    $deadline = microtime(true) + $ms / 1000;
+    while (microtime(true) < $deadline) {
+        // busy loop, no yield point
+    }
+}
+
+$main = spawn(function () {
+    $scope = new Scope();
+
+    $scope->spawn(function () {
+        burn_cpu_ms(300);             // makes loop->time stale, longer than the delay below
+        $before = microtime(true);
+        delay(150);
+        $elapsed = microtime(true) - $before;
+        echo "delay waited: " . ($elapsed >= 0.1 ? "yes" : "no") . "\n";
+    });
+
+    $scope->spawn(function () {
+        delay(50);                    // concurrent timer, keeps the loop from blocking on A's timer alone
+    });
+
+    $scope->awaitCompletion(\Async\timeout(5000));
+});
+
+await($main);
+echo "done\n";
+
+?>
+--EXPECT--
+delay waited: yes
+done


### PR DESCRIPTION
Fixes #185.

## Problem

`Async\delay()` / `Async\timeout()` fired almost instantly instead of waiting when a coroutine performed enough synchronous (non-yielding) CPU work to exceed the timeout it was about to arm — a **silent** skip of the wait, not a visible late fire.

libuv computes a timer's deadline as `loop->time + timeout`, where `loop->time` is the cached loop clock refreshed only once per `uv_run` iteration (not on every `uv_timer_start`). A coroutine that burns CPU without yielding for longer than the timeout it then arms leaves that clock stale, so the deadline is already in the past and the timer fires on the next loop check.

## Fix

New timer-event flag `ZEND_ASYNC_TIMER_F_REFRESH_CLOCK` (php-src `Zend/zend_async_API.h`), set by the relative userland-timeout paths only:
- `delay()` / `await(..., timeout)` via `zend_async_waker_new_with_timeout` (php-src)
- `Async\timeout()` via `async_timeout_create` (this repo)

`libuv_timer_start` refreshes `loop->time` (`uv_update_time`) **only when the flag is set**. Hot per-I/O deadline timers (armed right after the loop refreshed its clock on poll wakeup, and the most frequent arm path) leave the flag unset and pay only a predicted-not-taken branch — no clock read. The refresh (~a single monotonic vDSO read) is thus paid only at coroutine-suspension frequency.

Scoping at the arm point rather than only inside `zend_async_waker_new_with_timeout` also covers `Async\timeout()`, which arms through a separate path.

## Companion php-src change

The flag definition and the `delay()`/waker side live in php-src; already merged to `true-async-stable` (commit on `true-async` `0b63747276`, merged as `4084f0c487`). This repo's CI clones php-src `true-async-stable`, so the flag is present.

## Test

`tests/sleep/007-delay_after_cpu_burn.phpt` — a coroutine burns 300ms of CPU then `delay(150)`; a concurrent `delay(50)` is what exposes the bug (with a single timer libuv's relative poll timeout hides the staleness). Verified as a real canary: **without** the fix it fails 8/8 (`delay waited: no`, ~0ms), **with** the fix it passes deterministically under parallel load (elapsed 149–151ms). Timers only ever fire late, never early, so the lower bound cannot flake.

Full local `ext/async` suite green (the 3 curl/io failures are the known local `ext/async`→worktree symlink path artifact, unrelated).
