### PR TITLE
#201/#202/#203: pooled PDO crashes and unapplied driver options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Async extension for PHP will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **`PDO::ATTR_POOL_ENABLED` now rejects driver-specific constructor options instead of dropping them (#203).** The pool factory creates its connections without the option array, so options such as `Pdo\Mysql::ATTR_SSL_CA` never reached the wire and enabling the pool silently turned a TLS-configured connection into a plaintext one. Passing any option at or above `PDO::ATTR_DRIVER_SPECIFIC` together with the pool now throws, until per-slot configuration is implemented.
+
+### Fixed
+- **Segfault: `Pdo\Mysql::getWarningCount()` under `PDO::ATTR_POOL_ENABLED` (#201).** In pool mode the userland `PDO` is a template whose `driver_data` is always `NULL`, and the method dereferenced it unconditionally — one line of userland code was enough. It now reads the slot bound to the current coroutine and reports `0` when no slot is held. The mysqlnd reverse-API entry point had the same defect.
+
+- **Segfault: a coroutine finalizing with an open transaction after its `PDO` was destroyed (#202).** Handing the still-pinned connection back performs driver I/O, which suspends the finalizing coroutine; the `PDO` could be torn down while it was parked, leaving the callback to dereference a handle that teardown had already cleared. The callback now re-checks the handle after the release.
+
+- **`PDO::ATTR_POOL_STMT_CACHE_SIZE` opened a pooled connection merely by being passed to the constructor.** It sat outside the range of pool attributes consumed by pool setup, so it was dispatched to the driver as an ordinary attribute — and that dispatch acquires a slot.
+
 ## [0.8.0] - 2026-07-15
 
 ### Changed


### PR DESCRIPTION
Changelog for three pooled-PDO fixes landed in php-src `true-async-stable` (`01ce20dfbb`).

- **#203** — `PDO::ATTR_POOL_ENABLED` now refuses driver-specific constructor options instead of dropping them. The pool factory builds its connections with `options = NULL`, so `Pdo\Mysql::ATTR_SSL_CA` and friends never reached the wire: enabling the pool silently turned a TLS-configured connection into a plaintext one, with no error and nothing in the logs.
- **#201** — `Pdo\Mysql::getWarningCount()` segfaulted on a pooled PDO: it dereferenced the template, whose `driver_data` is always `NULL` in pool mode. Now reads the slot bound to the current coroutine. The mysqlnd reverse-API entry point had the same defect.
- **#202** — segfault when a coroutine finalized with an open transaction and its PDO was destroyed meanwhile: the release performs driver I/O and suspends, and teardown clears `binding->dbh` while the callback is parked.
- Plus: `PDO::ATTR_POOL_STMT_CACHE_SIZE` opened a connection just by being passed to the constructor.

## Verification

Each fix was checked by reverting it, not only by passing:

- #201 reproducer exits 139 before the fix, 0 after.
- #202 reproducer: SEGV in `pdo_pool_binding_on_coroutine_finish` under ASAN without the fix; clean under ASAN and valgrind with it.
- #203 / stmt-cache: new phpt fail on the pre-fix binary.

Four new tests: `ext/pdo/tests/pdo_pool_022`, `pdo_pool_023`, `ext/pdo_sqlite/tests/pool_012`, `pool_013`.

Full local suite (24568 tests): 13 failures, none in PDO — byte-identical to the list produced by a binary built without these changes, so no regressions.