### PR TITLE
#203: pooled PDO slot configuration (TLS options, setAttribute, inTransaction, POOL_MIN)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-- **`PDO::ATTR_POOL_ENABLED` now rejects driver-specific constructor options instead of dropping them (#203).** The pool factory creates its connections without the option array, so options such as `Pdo\Mysql::ATTR_SSL_CA` never reached the wire and enabling the pool silently turned a TLS-configured connection into a plaintext one. Passing any option at or above `PDO::ATTR_DRIVER_SPECIFIC` together with the pool now throws, until per-slot configuration is implemented.
-
 ### Fixed
+- **Pooled `PDO` connections silently ignored the TLS options the constructor asked for (#203).** The pool factory created every connection without the option array, so `Pdo\Mysql::ATTR_SSL_CA` and the rest of the `SSL_*` family never reached the wire: enabling the pool turned a TLS-configured connection into a plaintext one, with no error and nothing in the logs. The same path re-enabled `ATTR_MULTI_STATEMENTS` for users who had switched it off. Constructor options are now kept on the template and applied to every connection the pool creates.
+
+- **`PDO::setAttribute()` reached only one pooled connection (#203).** The driver wrote the value onto whichever slot was bound at the time, so slots created later kept the value they were born with. With `ATTR_AUTOCOMMIT` that lost data — coroutines landing on a fresh slot committed rows their `rollBack()` was meant to undo, while `getAttribute()` reported `false` the whole time. Accepted attributes are now recorded and re-applied per slot.
+
+- **`PDO::inTransaction()` took a pooled connection it did not need (#203).** A transaction pins the slot that opened it, so with no slot bound there is nothing to be inside of. Acquiring one for a call that answers "no transaction" left it pinned for the rest of the request in the main flow, and frameworks that check defensively hit `ATTR_POOL_MAX` far sooner than the workload warranted.
+
+- **`PDO::ATTR_POOL_MIN` created no connections at all (#203).** The pool pre-warms inside its own constructor, before the PDO template it builds connections from is attached, so the warm-up always failed silently whatever the value was.
 - **Segfault: `Pdo\Mysql::getWarningCount()` under `PDO::ATTR_POOL_ENABLED` (#201).** In pool mode the userland `PDO` is a template whose `driver_data` is always `NULL`, and the method dereferenced it unconditionally — one line of userland code was enough. It now reads the slot bound to the current coroutine and reports `0` when no slot is held. The mysqlnd reverse-API entry point had the same defect.
 
 - **Segfault: a coroutine finalizing with an open transaction after its `PDO` was destroyed (#202).** Handing the still-pinned connection back performs driver I/O, which suspends the finalizing coroutine; the `PDO` could be torn down while it was parked, leaving the callback to dereference a handle that teardown had already cleared. The callback now re-checks the handle after the release.

--- a/tests/pdo_pgsql/023-pdo_pgsql_pool_healthcheck_close.phpt
+++ b/tests/pdo_pgsql/023-pdo_pgsql_pool_healthcheck_close.phpt
@@ -53,9 +53,9 @@ echo "Done\n";
 ?>
 --EXPECT--
 Pool created with healthcheck
-Initial count: 0
+Initial count: 2
 Query: test
 After healthcheck delay
-Pool count: 1
+Pool count: 2
 PDO destroyed (no crash)
 Done


### PR DESCRIPTION
Changelog for the acquire half of #203, landed in php-src `true-async-stable` (`6d64baedf3`).

A pooled slot carried no configuration contract: nothing was applied when it was created, and nothing when it was handed out.

- **Constructor options now reach the slots.** `pdo_pool_factory()` called the driver with `options = NULL`, so every driver-specific option was dropped — silently turning a TLS-configured `PDO` into a plaintext one, and re-enabling `ATTR_MULTI_STATEMENTS` for users who had switched it off. This supersedes the stopgap refusal shipped in #209; that entry is removed from `[Unreleased]` since it never reached a release.
- **`setAttribute()` now reaches every slot.** It was written onto whichever slot was bound at the time, so later slots kept their birth value. With `ATTR_AUTOCOMMIT` that lost data.
- **`inTransaction()` no longer takes a slot.**
- **`ATTR_POOL_MIN` works at all** — the pool pre-warms inside its own constructor, before the template is attached, so the warm-up always failed silently.

Bumps `PDO_DRIVER_API` for the two new `pdo_dbh_t` fields.

## Verification

Reproduced each defect first, then checked each fix by reverting it:

- TLS: with a deliberately unusable CA, `direct` refuses and `pooled` used to connect with an empty `Ssl_cipher`. Both now refuse identically.
- `ATTR_MULTI_STATEMENTS => false`: honoured in pooled mode, matching direct.
- `ATTR_AUTOCOMMIT`: 4 coroutines used to report `autocommit=1` on 3 of 4 slots and leak rows past `rollBack()`; now `0,0,0,0` and no rows survive.
- `POOL_MIN`: 0/1/3/5 produced `count=0` for every value; now matches.
- `inTransaction()`: used to move `active` 0 → 1 for a call answering "no transaction".

Four new tests (`pdo_pool_024`, `pool_012`, `pool_014`, `pool_015`), each confirmed to fail on the pre-fix binary.

Full local suite (24574 tests): 13 failures, none in PDO — same set as the pre-change baseline.

## Not in this PR

The release half of #203 stays open: resetting session state on release (`COM_RESET_CONNECTION` / `DISCARD ALL`) and rolling back transactions opened with raw SQL, which needs `in_transaction()` rather than PDO's own flag. That work must follow this one — a reset before re-application would undo the attributes this PR restores.