### PR TITLE
Count a resource that exists but is not available for acquisition

### DIFF
--- a/pool.c
+++ b/pool.c
@@ -615,9 +615,20 @@ static void pool_healthcheck_timer_callback(zend_async_event_t *timer_event,
 			break;
 		}
 
+		/* The check yields: keep the resource counted while it is out. */
+		pool->active_count++;
+
 		bool is_healthy = pool_call_healthcheck(pool, &resource);
 
+		pool->active_count--;
+
 		if (is_healthy) {
+			/* Closed while we checked: close already drained idle. */
+			if (ZEND_ASYNC_POOL_IS_CLOSED(pool)) {
+				pool_destroy_resource(pool, &resource);
+				break;
+			}
+
 			/* Resource is healthy - return to buffer */
 			zval_circular_buffer_push(&pool->idle, &resource, true);
 			zval_ptr_dtor(&resource);
@@ -828,18 +839,24 @@ retry:
 		zval resource;
 		zval_circular_buffer_pop(&pool->idle, &resource);
 
+		/* Reserve before beforeAcquire: it may yield, and until then the
+		 * resource is in neither idle nor active_count. */
+		pool->active_count++;
+
 		/* beforeAcquire check (if set) */
 		if (!pool_call_before_acquire(pool, &resource)) {
 			/* Check failed - destroy and try next */
+			pool->active_count--;
 			pool_destroy_resource(pool, &resource);
 			if (UNEXPECTED(EG(exception))) {
+				/* Capacity freed: a waiter would never be woken otherwise. */
+				pool_wake_waiter(pool);
 				return false;
 			}
 			goto retry;
 		}
 
 		ZVAL_COPY_VALUE(result, &resource);
-		pool->active_count++;
 		return true;
 	}
 
@@ -899,14 +916,21 @@ retry:
 		zval resource;
 		zval_circular_buffer_pop(&pool->idle, &resource);
 
+		/* Reserve before a hook that may yield. */
+		pool->active_count++;
+
 		/* beforeAcquire check */
 		if (!pool_call_before_acquire(pool, &resource)) {
+			pool->active_count--;
 			pool_destroy_resource(pool, &resource);
+			if (UNEXPECTED(EG(exception))) {
+				pool_wake_waiter(pool);
+				return false;
+			}
 			goto retry;
 		}
 
 		ZVAL_COPY_VALUE(result, &resource);
-		pool->active_count++;
 		return true;
 	}
 
@@ -926,11 +950,14 @@ retry:
 
 void zend_async_pool_release(async_pool_t *pool, zval *resource)
 {
-	pool->active_count--;
-
 	/* beforeRelease callback (if set) */
 	/* Returns false = resource is broken, destroy it */
-	if (!pool_call_before_release(pool, resource)) {
+	const bool reusable = pool_call_before_release(pool, resource);
+
+	/* After the hook, which may yield. Exactly one decrement. */
+	pool->active_count--;
+
+	if (!reusable) {
 		/* Report failure to strategy */
 		pool_strategy_report_failure(pool, NULL);
 		pool_destroy_resource(pool, resource);

--- a/tests/pool/056-pool_counts_resource_during_hooks.phpt
+++ b/tests/pool/056-pool_counts_resource_during_hooks.phpt
@@ -1,0 +1,55 @@
+--TEST--
+Pool: a resource in a suspending hook is still counted against max
+--DESCRIPTION--
+Admission is decided on idle + active. beforeAcquire and beforeRelease may
+yield, and while they do the resource sits in neither — so a concurrent
+acquirer read capacity that did not exist and built one past max, which the
+pool never gave back. The resource has to stay counted for the whole hook.
+--FILE--
+<?php
+
+use function Async\spawn;
+use function Async\await;
+use function Async\delay;
+
+$factoryCalls = 0;
+
+$pool = new Async\Pool(
+    function() use (&$factoryCalls) { return ++$factoryCalls; },
+    null,                              // destructor
+    null,                              // healthcheck
+    function($r) { delay(30); return true; },   // beforeAcquire, suspends
+    function($r) { delay(30); return true; },   // beforeRelease, suspends
+    0,                                 // min
+    1,                                 // max
+);
+
+// Put one resource into idle, so the next acquire goes through beforeAcquire.
+$pool->release($pool->acquire());
+
+$counts = [];
+
+$user = spawn(function() use ($pool) {
+    $r = $pool->acquire();
+    delay(20);
+    $pool->release($r);
+});
+
+$probe = spawn(function() use ($pool, &$counts) {
+    for ($i = 0; $i < 8; $i++) {
+        $counts[] = $pool->count();
+        delay(10);
+    }
+});
+
+await($user);
+await($probe);
+
+echo "resource ever counted nowhere: ", in_array(0, $counts, true) ? "yes" : "no", "\n";
+echo "connections created: ", $factoryCalls, "\n";
+echo "Done\n";
+?>
+--EXPECT--
+resource ever counted nowhere: no
+connections created: 1
+Done


### PR DESCRIPTION
Found while reviewing the #203 session-isolation work: the cleanup added there suspends inside `beforeAcquire`, which made an existing accounting hole wide enough to matter.

## The hole

Admission is decided on `ASYNC_POOL_TOTAL = idle + active_count`. Three paths take a resource out of the idle buffer, do I/O that suspends, and only then account for it. For that whole window the resource is counted **nowhere**, so a concurrent acquirer reads capacity that does not exist and builds a connection past `max_size` — and nothing shrinks the pool afterwards.

| path | suspends around |
|---|---|
| acquire from idle | `beforeAcquire` — a driver may clean the session there, several round trips |
| release | `beforeRelease` — rolls a transaction back |
| healthcheck | the liveness check itself |

Measured, with a pooled PDO whose slot needed cleaning; `pool->count()` sampled from another coroutine while the cleanup ran:

```
without this change   0,1,1,1,1,1     <- the connection exists and is counted nowhere
with this change      1,1,1,1,1,1
```

## The rule

The factory path already reserved the slot before calling out, with a comment saying why. This applies the same reservation to the three paths above, so the rule becomes uniform: **a resource that exists is either in the idle buffer or counted in `active_count`, never in neither.** `active_count` therefore means "exists and cannot be handed out" — in use, or under maintenance. Release decrements at a single join point after the hook returns rather than per branch, so "exactly once" stays checkable by eye.

## What the reservation obliges

A coroutine can now legitimately park against a full pool where before it would have overshot instead. So any exit that frees the reservation without passing the resource on must wake a waiter, or that coroutine sleeps forever — the exception bail-out on the `beforeAcquire` failure path now does, and `try_acquire` (which checked for a pending exception nowhere, from when the hook could not suspend) checks and wakes too.

## Adjacent leak, fixed here

Closing a pool stops the healthcheck timer but cannot cancel a check already in flight. On resume the healthy branch pushed the connection into the idle buffer of a closed pool, which nothing drains again, so the connection stayed open until the process exited. The pool state is re-checked after the liveness call.

## Verification

Full php-async suite: 3 failures, all three pre-existing (`curl/063`, `curl/064`, `io/082`) and identical to the baseline. The `count()` comparison above was taken by reverting this change and re-running the same probe.