### PR TITLE
fix(thread): release multiple transferred roots under one visited set

### DIFF
--- a/libuv_reactor.c
+++ b/libuv_reactor.c
@@ -7161,4 +7161,8 @@ void async_libuv_reactor_register(void)
 			async_thread_transfer_zval, async_thread_load_zval,
 			async_thread_release_transferred_zval,
 			async_thread_xlat_put_ctx, async_thread_defer_release_ctx);
+
+	/* Batched multi-root release (one visited set). Additive; set directly rather
+	 * than widening zend_async_thread_pool_register's signature. */
+	zend_async_thread_release_transferred_zvals_fn = async_thread_release_transferred_zvals;
 }

--- a/thread.c
+++ b/thread.c
@@ -1401,6 +1401,20 @@ void async_thread_release_transferred_zval(zval *z)
 	ZVAL_UNDEF(z);
 }
 
+/* One release ctx (one visited set) across all roots — unlike the single-zval call,
+ * which builds a fresh set each time — so an object xlat-deduped into more than one
+ * root is freed once. Contract and rationale: the typedef in zend_async_API.h. */
+void async_thread_release_transferred_zvals(zval **roots, size_t count)
+{
+	thread_release_ctx_t ctx;
+	thread_release_ctx_init(&ctx);
+	for (size_t i = 0; i < count; i++) {
+		thread_release_transferred_zval(&ctx, roots[i]);
+		ZVAL_UNDEF(roots[i]);
+	}
+	thread_release_ctx_destroy(&ctx);
+}
+
 /* Partial-release for build-error paths: refcount-based so xlat-shared
  * sub-pieces still owned by the half-built snapshot survive; the snapshot's
  * full release frees them shortly afterwards. */

--- a/thread.h
+++ b/thread.h
@@ -176,6 +176,7 @@ void async_thread_load_zval(zval *dst, const zval *src);
  * Free a persistent zval created by async_thread_transfer_zval().
  */
 void async_thread_release_transferred_zval(zval *z);
+void async_thread_release_transferred_zvals(zval **roots, size_t count);
 
 /* Recursion helpers passed to zend_async_thread_pool_register() — expose
  * thread_transfer_zval_inner / thread_load_zval_inner / xlat_put / a lazy


### PR DESCRIPTION
A transfer deep-copies an object graph under one ctx whose xlat table dedups shared objects (a closure capturing an object transferred beside it points at the same copy). Release dedups only WITHIN one `async_thread_release_transferred_zval` call — a fresh visited set each — so an embedder that stores several roots of one transfer and releases them separately freed a shared copy twice (double-free; UAF at shutdown). Adds `async_thread_release_transferred_zvals(roots, n)` — one visited set across all roots — and registers it. Needs the Zend-API addition (php-src PR). Repro'd + regressed by true-async/server.