### PR TITLE
Keep the EH_THROW window inside its own coroutine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Async extension for PHP will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **A warning raised in one coroutine could come back as another coroutine's exception class.** `zend_replace_error_handling(EH_THROW, $class)` makes the engine turn warnings into exceptions of `$class` instead of reporting them, and that window was global rather than per-fiber. `PDO::__construct` opens one around the connect, which parks the coroutine, so any warning raised meanwhile — in unrelated code, under `@`, with nothing to do with a database — surfaced as a `PDOException` carrying that warning's message. Twelve other extensions open the same kind of window (`spl_directory`, `date`, `spl_iterators`, `tidy`, `fileinfo`). The window now travels with the fiber, and a coroutine starts outside any of them. Needs php-src `Zend/zend_fibers.c` from the matching build.
+
 ## [0.8.3] - 2026-07-31
 
 ### Fixed

--- a/scheduler.c
+++ b/scheduler.c
@@ -1811,6 +1811,11 @@ ZEND_STACK_ALIGNED void fiber_entry(zend_fiber_transfer *transfer)
 		EG(current_execute_data) = execute_data;
 		EG(jit_trace_num) = 0;
 		EG(error_reporting) = (int) error_reporting;
+		/* A fiber starts outside anyone's EH_THROW window (zend_replace_error_handling):
+		 * inheriting one would paint this coroutine's warnings with a foreign
+		 * exception class. */
+		EG(error_handling) = EH_NORMAL;
+		EG(exception_class) = NULL;
 
 #ifdef ZEND_CHECK_STACK_LIMIT
 		EG(stack_base) = zend_fiber_stack_base(internal_fiber_context->stack);

--- a/tests/edge_cases/016-error_handling_window_not_shared.phpt
+++ b/tests/edge_cases/016-error_handling_window_not_shared.phpt
@@ -1,0 +1,50 @@
+--TEST--
+An EH_THROW window opened by another coroutine does not repaint our warnings
+--EXTENSIONS--
+pdo_mysql
+--SKIPIF--
+<?php
+if (!function_exists('Async\spawn')) die("skip TrueAsync runtime not available\n");
+?>
+--FILE--
+<?php
+
+use function Async\spawn;
+use function Async\await;
+use function Async\delay;
+
+/* PDO::__construct replaces the error handling mode for the duration of the
+ * connect (zend_replace_error_handling(EH_THROW, pdo_exception_ce)), and the
+ * connect parks the coroutine. While it sleeps, a warning raised anywhere else
+ * must stay a warning: if the window were global, the engine would turn it into
+ * a PDOException carrying someone else's message. 10.255.255.1 is unroutable, so
+ * the connect stays parked until it times out. */
+$connector = spawn(function () {
+    try {
+        new PDO('mysql:host=10.255.255.1;port=3306;dbname=x', 'u', 'p', [PDO::ATTR_TIMEOUT => 3]);
+    } catch (Throwable $e) {
+        return 'connect ended';
+    }
+
+    return 'connect ended';
+});
+
+$victim = spawn(function () {
+    delay(50);
+
+    try {
+        $decoded = @gzdecode('');
+        return 'suppressed, got ' . var_export($decoded, true);
+    } catch (Throwable $e) {
+        return 'leaked ' . $e::class . ': ' . $e->getMessage();
+    }
+});
+
+echo await($victim), "\n";
+echo await($connector), "\n";
+echo "Done\n";
+?>
+--EXPECT--
+suppressed, got false
+connect ended
+Done


### PR DESCRIPTION
Root cause of YanGusik/laravel-spawn#25, and it turned out to be ours.

## What was happening

`zend_replace_error_handling(EH_THROW, $ce)` switches the engine into a mode where a warning is not reported but turned into an exception of `$ce`:

```c
/* main/main.c */
if (EG(error_handling) == EH_THROW) {
    switch (type) {
        case E_WARNING: ...
            if (!EG(exception)) {
                zend_throw_error_exception(EG(exception_class), message, 0, type);
            }
            return;
```

`EG(error_handling)` and `EG(exception_class)` were **not** per-fiber, so that window did not belong to the code that opened it — it belonged to whichever coroutine happened to be running.

`PDO::__construct` opens one around the connect (`ext/pdo/pdo_dbh.c`), and under the reactor the connect parks the coroutine. Everything that ran while it slept was inside PDO's window.

## What it looked like from the outside

A production Laravel app got this from `@gzdecode($value)` in a class that has nothing to do with databases:

```
class:   PDOException
message: gzdecode(): data error
#0 GzipService.php(19): gzdecode('')
```

Three things that made it hard to read, all explained by the same line:

- **the class is wrong** — it comes from `EG(exception_class)`, i.e. PDO's;
- **`@` did not help** — the conversion happens before any reporting logic, so the silence mask never enters into it;
- **no error-handler frame in the trace** — with `error_handling != EH_NORMAL` the engine skips the userland handler entirely and goes straight to `zend_error_cb`.

## The fix, and why it is two halves

A coroutine can meet a foreign window in two distinct ways, and they need different protection:

| | protected by |
|---|---|
| created **while** a window is open — it would inherit it | the `EH_NORMAL` reset in `fiber_entry()` (this PR) |
| parked before the window existed, resumed **inside** it | `error_handling` / `exception_class` travelling with the fiber (php-src `Zend/zend_fibers.c`, already on `true-async-stable`) |

Each half was removed in turn to confirm both are load-bearing: without the reset test 016 fails, without capture/restore test 017 fails.

A third, defensive reset in upstream's `zend_fiber_execute()` was dropped again: it would protect a plain `Fiber` started from inside a window, but that case cannot be constructed today — the extensions that open one do not call into userland inside it — so it was shipping unverified changes to core semantics.

## Blast radius

PDO is not special, only unlucky: its window contains network I/O, so it is guaranteed to park. `zend_replace_error_handling(EH_THROW, ...)` appears in 13 places — `spl_directory` (5), `date` (4), `spl_iterators`, `tidy`, `fileinfo`, `pdo`. Any of them will do the same if a suspension lands inside.

Upstream PHP has the same gap, but it cannot fire there: a plain `Fiber` has no way to suspend inside a PDO connect.

## Tests

Both need no database — they park on a connect to an unroutable address.

- `016-error_handling_window_not_shared.phpt` — victim created while the window is open;
- `017-error_handling_window_not_inherited_on_resume.phpt` — victim parked before it, resumed inside it.

Local runs on the final combination: `Zend/tests` 5199 passed / 0 failed, `ext/async/tests` 1129 passed / 0 failed (from a real path, not through the symlink), `ext/pdo` + `ext/pdo_sqlite` + `ext/standard/tests/general_functions` 518 passed / 0 failed.
