### PR TITLE
EH_THROW window: one mechanism, and tests that need no database

### DIFF
--- a/scheduler.c
+++ b/scheduler.c
@@ -1811,11 +1811,6 @@ ZEND_STACK_ALIGNED void fiber_entry(zend_fiber_transfer *transfer)
 		EG(current_execute_data) = execute_data;
 		EG(jit_trace_num) = 0;
 		EG(error_reporting) = (int) error_reporting;
-		/* A fiber starts outside anyone's EH_THROW window (zend_replace_error_handling):
-		 * inheriting one would paint this coroutine's warnings with a foreign
-		 * exception class. */
-		EG(error_handling) = EH_NORMAL;
-		EG(exception_class) = NULL;
 
 #ifdef ZEND_CHECK_STACK_LIMIT
 		EG(stack_base) = zend_fiber_stack_base(internal_fiber_context->stack);

--- a/tests/edge_cases/016-error_handling_window_not_shared.phpt
+++ b/tests/edge_cases/016-error_handling_window_not_shared.phpt
@@ -1,7 +1,7 @@
 --TEST--
-An EH_THROW window opened by another coroutine does not repaint our warnings
+An EH_THROW window does not follow a coroutine spawned inside it
 --EXTENSIONS--
-pdo_mysql
+zlib
 --SKIPIF--
 <?php
 if (!function_exists('Async\spawn')) die("skip TrueAsync runtime not available\n");
@@ -13,38 +13,63 @@ use function Async\spawn;
 use function Async\await;
 use function Async\delay;
 
-/* PDO::__construct replaces the error handling mode for the duration of the
- * connect (zend_replace_error_handling(EH_THROW, pdo_exception_ce)), and the
- * connect parks the coroutine. While it sleeps, a warning raised anywhere else
- * must stay a warning: if the window were global, the engine would turn it into
- * a PDOException carrying someone else's message. 10.255.255.1 is unroutable, so
- * the connect stays parked until it times out. */
-$connector = spawn(function () {
-    try {
-        new PDO('mysql:host=10.255.255.1;port=3306;dbname=x', 'u', 'p', [PDO::ATTR_TIMEOUT => 3]);
-    } catch (Throwable $e) {
-        return 'connect ended';
+/* DirectoryIterator::__construct turns warnings into UnexpectedValueException for
+ * the duration of the directory open (zend_replace_error_handling), and the open
+ * goes through a userland wrapper — so a coroutine can be spawned, and the holder
+ * can park, while that mode is in force. The spawned coroutine is a separate flow
+ * of control: its own warning must stay a warning, whatever the holder is doing.
+ * PDO::__construct holds the same kind of window across its connect, which is how
+ * this surfaced downstream, but a wrapper reproduces it without a database. */
+
+class WindowedDirectory
+{
+    public static ?object $spawned = null;
+
+    public $context;
+
+    public function dir_opendir(string $path, int $options): bool
+    {
+        self::$spawned = spawn(static function (): string {
+            try {
+                return 'suppressed, got ' . var_export(@gzdecode(''), true);
+            } catch (Throwable $e) {
+                return 'leaked ' . $e::class . ': ' . $e->getMessage();
+            }
+        });
+
+        delay(50);
+
+        return false;
     }
 
-    return 'connect ended';
-});
-
-$victim = spawn(function () {
-    delay(50);
-
-    try {
-        $decoded = @gzdecode('');
-        return 'suppressed, got ' . var_export($decoded, true);
-    } catch (Throwable $e) {
-        return 'leaked ' . $e::class . ': ' . $e->getMessage();
+    public function dir_readdir(): string|false
+    {
+        return false;
     }
+
+    public function dir_closedir(): bool
+    {
+        return true;
+    }
+}
+
+stream_wrapper_register('windowed', WindowedDirectory::class);
+
+$holder = spawn(static function (): string {
+    try {
+        new DirectoryIterator('windowed://dir');
+    } catch (Throwable $e) {
+        return 'holder: ' . $e::class;
+    }
+
+    return 'holder: no exception';
 });
 
-echo await($victim), "\n";
-echo await($connector), "\n";
+echo await($holder), "\n";
+echo await(WindowedDirectory::$spawned), "\n";
 echo "Done\n";
 ?>
 --EXPECT--
+holder: UnexpectedValueException
 suppressed, got false
-connect ended
 Done

--- a/tests/edge_cases/017-error_handling_window_not_inherited_on_resume.phpt
+++ b/tests/edge_cases/017-error_handling_window_not_inherited_on_resume.phpt
@@ -1,0 +1,75 @@
+--TEST--
+An EH_THROW window opened while we were parked does not follow us on resume
+--EXTENSIONS--
+zlib
+--SKIPIF--
+<?php
+if (!function_exists('Async\spawn')) die("skip TrueAsync runtime not available\n");
+?>
+--FILE--
+<?php
+
+use function Async\spawn;
+use function Async\await;
+use function Async\delay;
+
+/* Companion to 016. There the victim is spawned while the window is already open,
+ * so what protects it is starting outside one. Here it is parked before the window
+ * exists and wakes up in the middle of it, so what protects it is the context
+ * switch carrying the mode per fiber. */
+
+class WindowedDirectory
+{
+    public $context;
+
+    public function dir_opendir(string $path, int $options): bool
+    {
+        delay(100);
+
+        return false;
+    }
+
+    public function dir_readdir(): string|false
+    {
+        return false;
+    }
+
+    public function dir_closedir(): bool
+    {
+        return true;
+    }
+}
+
+stream_wrapper_register('windowed', WindowedDirectory::class);
+
+$victim = spawn(static function (): string {
+    delay(10);
+    delay(60); // Wakes up while the holder sits inside the window.
+
+    try {
+        return 'suppressed, got ' . var_export(@gzdecode(''), true);
+    } catch (Throwable $e) {
+        return 'leaked ' . $e::class . ': ' . $e->getMessage();
+    }
+});
+
+$holder = spawn(static function (): string {
+    delay(30);
+
+    try {
+        new DirectoryIterator('windowed://dir');
+    } catch (Throwable $e) {
+        return 'holder: ' . $e::class;
+    }
+
+    return 'holder: no exception';
+});
+
+echo await($victim), "\n";
+echo await($holder), "\n";
+echo "Done\n";
+?>
+--EXPECT--
+suppressed, got false
+holder: UnexpectedValueException
+Done


### PR DESCRIPTION
Follow-up to #214, against php-src `true-async-stable` bfb4525597.

**Tests.** 016 as merged held the window open with a PDO connect to an unroutable address and gave the victim 50 ms to run inside it. If the network answered quickly the window was already closed by then, and the test passed without exercising anything — green either way. A userland stream wrapper under `DirectoryIterator` reaches the same `zend_replace_error_handling(EH_THROW, …)` window and parks inside it on a timer we control, so both halves are covered with no `pdo_mysql`, no routing assumptions and no three-second timeout. 017 covers the resume half and never landed with #214.

**Scheduler.** `zend_fiber_switch_context` now clears the window before the jump, so a coroutine's fiber starts outside any of them whichever way it is entered. The reset in `fiber_entry` was a second mechanism for one invariant, and neither was visibly load-bearing; it goes.

Verified by removing each half in turn: with the engine change and without the `fiber_entry` reset, 016 and 017 both pass; with neither, both fail.