### PR TITLE
Release the SIGCHLD watch when the last process event goes

### DIFF
--- a/libuv_reactor.c
+++ b/libuv_reactor.c
@@ -1083,10 +1083,8 @@ static bool libuv_timer_start(zend_async_event_t *event)
 		return false;
 	}
 
-	// A hidden timer is a background heartbeat — a connection pool healthcheck,
-	// say. Keeping it out of active_event_count is not enough: the uv handle
-	// still holds a loop reference, so uv_run never returns and the process
-	// hangs with no work left to do.
+	// Hidden means "keeps firing, but is not a reason to stay alive": unref drops
+	// the timer out of uv_loop_alive() without stopping it.
 	if (ZEND_ASYNC_EVENT_IS_HIDDEN(event)) {
 		uv_unref((uv_handle_t *) &timer->uv_handle);
 	}
@@ -1663,10 +1661,8 @@ static void libuv_handle_process_events(void)
 			ZEND_ASYNC_CALLBACKS_NOTIFY(event, NULL, NULL);
 			// Process event will be removed when stopped
 		}
-		/* ECHILD is deliberately not treated as "settle this event": a notified
-		 * event stays in the table until its waiter resumes, so a second sweep
-		 * before that sees ECHILD for the child this sweep just reaped, and
-		 * settling again would overwrite the exit code with a made-up one. */
+		// ECHILD is not settled here: a notified event outlives this sweep, so a
+		// second sweep would overwrite its exit code with a made-up one.
 #endif
 	}
 
@@ -1707,14 +1703,8 @@ static void libuv_add_process_event(zend_async_event_t *event)
 /* }}} */
 
 /* {{{ libuv_release_process_watch
- *
- * Drops the SIGCHLD machinery once the last process event is gone.
- *
- * Called from every path that empties the table, not just the stop path: an
- * event released while already stopped is deleted straight from the hash, and
- * without this the handler outlives the last watcher. Nothing raises it again,
- * yet it holds the reactor loop, so the process runs out of work and still
- * refuses to exit. */
+ * Drops the SIGCHLD handler once the last process event is gone. Call from every
+ * path that empties the table. */
 static void libuv_release_process_watch(void)
 {
 	if (ASYNC_G(process_events) == NULL || zend_hash_num_elements(ASYNC_G(process_events)) > 0) {
@@ -1723,6 +1713,7 @@ static void libuv_release_process_watch(void)
 
 	bool has_sigchld_signal_events = false;
 
+	// Check if there are regular signal events for SIGCHLD
 	if (ASYNC_G(signal_events) != NULL) {
 		HashTable *sigchld_events = zend_hash_index_find_ptr(ASYNC_G(signal_events), SIGCHLD);
 		if (sigchld_events != NULL && zend_hash_num_elements(sigchld_events) > 0) {
@@ -1730,15 +1721,12 @@ static void libuv_release_process_watch(void)
 		}
 	}
 
-	// A plain signal() subscriber on SIGCHLD owns the handler for as long as it waits.
+	// Only remove handler if no signal events exist for SIGCHLD
 	if (!has_sigchld_signal_events && ASYNC_G(signal_handlers) != NULL) {
 		uv_signal_t *handler = zend_hash_index_find_ptr(ASYNC_G(signal_handlers), SIGCHLD);
 		if (handler != NULL) {
 			if ((bool) (uintptr_t) handler->data) {
-				/* A Zend-chain subscriber (pcntl etc.) still needs delivery —
-				 * keep the handler armed but stop pinning the loop, exactly as
-				 * libuv_remove_signal_event does. Closing it here would revert
-				 * the OS disposition and leave that subscriber permanently deaf. */
+				// pcntl still needs delivery; closing reverts the OS disposition.
 				uv_unref((uv_handle_t *) handler);
 			} else {
 				uv_signal_stop(handler);

--- a/libuv_reactor.c
+++ b/libuv_reactor.c
@@ -1083,6 +1083,14 @@ static bool libuv_timer_start(zend_async_event_t *event)
 		return false;
 	}
 
+	// A hidden timer is a background heartbeat — a connection pool healthcheck,
+	// say. Keeping it out of active_event_count is not enough: the uv handle
+	// still holds a loop reference, so uv_run never returns and the process
+	// hangs with no work left to do.
+	if (ZEND_ASYNC_EVENT_IS_HIDDEN(event)) {
+		uv_unref((uv_handle_t *) &timer->uv_handle);
+	}
+
 	event->loop_ref_count++;
 	ZEND_ASYNC_INCREASE_EVENT_COUNT(event);
 	return true;
@@ -1655,6 +1663,10 @@ static void libuv_handle_process_events(void)
 			ZEND_ASYNC_CALLBACKS_NOTIFY(event, NULL, NULL);
 			// Process event will be removed when stopped
 		}
+		/* ECHILD is deliberately not treated as "settle this event": a notified
+		 * event stays in the table until its waiter resumes, so a second sweep
+		 * before that sees ECHILD for the child this sweep just reaped, and
+		 * settling again would overwrite the exit code with a made-up one. */
 #endif
 	}
 
@@ -1694,6 +1706,58 @@ static void libuv_add_process_event(zend_async_event_t *event)
 
 /* }}} */
 
+/* {{{ libuv_release_process_watch
+ *
+ * Drops the SIGCHLD machinery once the last process event is gone.
+ *
+ * Called from every path that empties the table, not just the stop path: an
+ * event released while already stopped is deleted straight from the hash, and
+ * without this the handler outlives the last watcher. Nothing raises it again,
+ * yet it holds the reactor loop, so the process runs out of work and still
+ * refuses to exit. */
+static void libuv_release_process_watch(void)
+{
+	if (ASYNC_G(process_events) == NULL || zend_hash_num_elements(ASYNC_G(process_events)) > 0) {
+		return;
+	}
+
+	bool has_sigchld_signal_events = false;
+
+	if (ASYNC_G(signal_events) != NULL) {
+		HashTable *sigchld_events = zend_hash_index_find_ptr(ASYNC_G(signal_events), SIGCHLD);
+		if (sigchld_events != NULL && zend_hash_num_elements(sigchld_events) > 0) {
+			has_sigchld_signal_events = true;
+		}
+	}
+
+	// A plain signal() subscriber on SIGCHLD owns the handler for as long as it waits.
+	if (!has_sigchld_signal_events && ASYNC_G(signal_handlers) != NULL) {
+		uv_signal_t *handler = zend_hash_index_find_ptr(ASYNC_G(signal_handlers), SIGCHLD);
+		if (handler != NULL) {
+			if ((bool) (uintptr_t) handler->data) {
+				/* A Zend-chain subscriber (pcntl etc.) still needs delivery —
+				 * keep the handler armed but stop pinning the loop, exactly as
+				 * libuv_remove_signal_event does. Closing it here would revert
+				 * the OS disposition and leave that subscriber permanently deaf. */
+				uv_unref((uv_handle_t *) handler);
+			} else {
+				uv_signal_stop(handler);
+#ifdef ZEND_SIGNALS
+				libuv_restore_signal_handler(SIGCHLD);
+#endif
+				uv_close((uv_handle_t *) handler, libuv_signal_close_cb);
+				zend_hash_index_del(ASYNC_G(signal_handlers), SIGCHLD);
+			}
+		}
+	}
+
+	zend_hash_destroy(ASYNC_G(process_events));
+	pefree(ASYNC_G(process_events), 0);
+	ASYNC_G(process_events) = NULL;
+}
+
+/* }}} */
+
 /* {{{ libuv_remove_process_event */
 static void libuv_remove_process_event(zend_async_event_t *event)
 {
@@ -1706,32 +1770,7 @@ static void libuv_remove_process_event(zend_async_event_t *event)
 
 	zend_hash_index_del(ASYNC_G(process_events), (uintptr_t) process_event->event.process);
 
-	// Only remove SIGCHLD handler if no more process events AND no regular signal events for SIGCHLD
-	if (zend_hash_num_elements(ASYNC_G(process_events)) == 0) {
-		bool has_sigchld_signal_events = false;
-
-		// Check if there are regular signal events for SIGCHLD
-		if (ASYNC_G(signal_events) != NULL) {
-			HashTable *sigchld_events = zend_hash_index_find_ptr(ASYNC_G(signal_events), SIGCHLD);
-			if (sigchld_events != NULL && zend_hash_num_elements(sigchld_events) > 0) {
-				has_sigchld_signal_events = true;
-			}
-		}
-
-		// Only remove handler if no signal events exist for SIGCHLD
-		if (!has_sigchld_signal_events && ASYNC_G(signal_handlers) != NULL) {
-			uv_signal_t *handler = zend_hash_index_find_ptr(ASYNC_G(signal_handlers), SIGCHLD);
-			if (handler != NULL) {
-				uv_signal_stop(handler);
-				uv_close((uv_handle_t *) handler, libuv_signal_close_cb);
-				zend_hash_index_del(ASYNC_G(signal_handlers), SIGCHLD);
-			}
-		}
-
-		zend_hash_destroy(ASYNC_G(process_events));
-		pefree(ASYNC_G(process_events), 0);
-		ASYNC_G(process_events) = NULL;
-	}
+	libuv_release_process_watch();
 }
 
 /* }}} */
@@ -2170,6 +2209,7 @@ static bool libuv_process_event_dispose(zend_async_event_t *event)
 	const zend_process_t proc_handle = ((zend_async_process_event_t *) event)->process;
 	if ((uintptr_t) proc_handle != 0 && ASYNC_G(process_events) != NULL) {
 		zend_hash_index_del(ASYNC_G(process_events), (zend_ulong) (uintptr_t) proc_handle);
+		libuv_release_process_watch();
 	}
 
 #ifdef PHP_WIN32


### PR DESCRIPTION
Closes #216.

A worker drains its queue, prints its final stats and then hangs until killed. Under gdb the main thread sits in `uv__io_poll` with `timeout=-1` from `libuv_reactor_execute(no_wait=false)`; a `uv_walk` dump at that point shows `active_event_count` down to 1 and one live handle — `signal`, `signum=17`. No child processes exist, live or zombie.

## Two causes, both in this file

**`libuv_process_event_dispose()` empties the table behind the teardown's back.** It deletes the entry from `ASYNC_G(process_events)` directly — the line guarding against a stale hash pointer — while the SIGCHLD teardown lives only in `libuv_remove_process_event()`. An event released while already stopped leaves the table empty and the handler armed. The teardown is now `libuv_release_process_watch()`, called from both paths.

**A hidden timer still pins the loop.** `pool_start_healthcheck_timer()` marks its timer HIDDEN precisely so an idle pool cannot block a graceful shutdown, but that flag only keeps the event out of `active_event_count`. `uv_timer_start` leaves the handle referenced, so `uv_run` never returns. The thread-notify handles in this file already work around it with a manual `uv_unref`; timers now do the same.

## Measurements

Stand: a Laravel queue worker on thrun threads, 4 threads, jobs that touch the database.

| build | hangs |
|---|---|
| unchanged | 8 of 8 with the pool healthcheck on, 1-2 of 8 with it off |
| timer unref only | 1 of 8 |
| both | 0 of 30 |

Removing either fix from the final build brings the hang back on the first or second run.

Suite: 1126 pass, the same 3 failures as baseline (`curl/063`, `curl/064`, `io/082`) — they fail on an unpatched binary too.

## What is deliberately not here

An earlier draft settled the event on `ECHILD` in `libuv_handle_process_events()`, on the theory that a child reaped by `proc_close()`/`pclose()` leaves the event waiting forever. That branch corrupts exit codes: a notified event stays in the table until its waiter resumes, so a second sweep before that sees `ECHILD` for the child the first sweep just reaped and overwrites `exit_code` with `-1`. Two children exiting close together while the scheduler runs PHP code — an ordinary shape — turned `proc_close()` results of 7 and 9 into -1 and -1, deterministically. A comment now records why that branch must not come back.

A draft also polled processes from `libuv_reactor_execute()` before the blocking `uv_run`. Measured unnecessary once the teardown was fixed — 30 clean runs without it — and removed rather than left in the reactor's hot path.

## Known and unchanged

`libuv_handle_process_events()` reads the pid out of a copied event pointer before checking that the entry is still in the table. Unreachable today: in scheduler context the notify callbacks only enqueue coroutines, no PHP code runs inline, and every copied event holds two references for the duration of the sweep. It would become reachable if the sweep ever ran outside scheduler context *and* one waker held two process events. Left as it was — the minimal hardening would be to copy hash keys instead of event pointers.