### PR TITLE
Follow upstream diagnostics in three test expectations

### DIFF
--- a/tests/curl/025-write_file_broken_pipe.phpt
+++ b/tests/curl/025-write_file_broken_pipe.phpt
@@ -46,6 +46,7 @@ async_test_server_stop($server);
 echo "Done\n";
 ?>
 --EXPECTF--
+Warning: Unknown: Send of %d bytes failed with errno=%d %s in Unknown on line 0
 curl_exec returned: false
 errno: 23
 is write error: yes

--- a/tests/curl/054-multi_write_file_broken_pipe.phpt
+++ b/tests/curl/054-multi_write_file_broken_pipe.phpt
@@ -60,6 +60,7 @@ async_test_server_stop($server);
 echo "Done\n";
 ?>
 --EXPECTF--
+Warning: Unknown: Send of %d bytes failed with errno=%d %s in Unknown on line 0
 Transfer result: CURLE_WRITE_ERROR
 curl_errno: CURLE_WRITE_ERROR
 Done

--- a/tests/io/082-http_negative_timeout_poll_leak.phpt
+++ b/tests/io/082-http_negative_timeout_poll_leak.phpt
@@ -29,5 +29,5 @@ var_dump(fopen($uri, "r", false, $ctx));
 --EXPECTF--
 resource(%d) of type (stream)
 
-Warning: fopen(http://%s): Failed to open stream: timeout must be lower than %d in %s on line %d
+Warning: fopen(): Failed to open stream: timeout must be lower than %d in %s on line %d
 bool(false)


### PR DESCRIPTION
php-src `true-async` was merged with upstream master. Two diagnostics changed there:

- `fopen()` reports the failure without repeating the URL in the message (`ext/standard/tests/http/gh16810.phpt` upstream expects the same wording).
- A failed socket send is now `E_WARNING` via `php_stream_warn()` instead of `E_NOTICE`, so the two broken-pipe curl tests see it despite `error_reporting=E_ALL & ~E_NOTICE`.

Expectations updated to match. Full suite locally: 1227 tests, 0 failed; fuzzy 875, 0 failed.