### PR TITLE
#219: dispose the Thread event from free_obj as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **A fatal error left every live `Async\Thread` holding an open libuv handle.** Before it bails out, the engine marks all objects as destructed, so `dtor_obj` never runs — and `Thread` released its event only from there. The cross-thread notify handle therefore survived reactor shutdown: `uv_loop_close()` returned `EBUSY`, the loop's internals and the persistent thread context leaked, and a debug build printed one "leftover libuv handle" line per thread. The release now also runs from `free_obj`, which the engine always calls.
+- **A fatal error left every live `Async\Thread` holding an open libuv handle.** `Thread` disposed its event from `dtor_obj` alone, and the engine marks all objects as destructed before it bails out, so a fatal error skipped that dispose entirely. The cross-thread notify handle then survived reactor shutdown: `uv_loop_close()` returned `EBUSY`, the loop's internals and the persistent thread context leaked, and a debug build printed one "leftover libuv handle" line per thread. The dispose now also runs from `free_obj`, which the engine always calls.
 
 ## [0.9.0] - 2026-08-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Async extension for PHP will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **A fatal error left every live `Async\Thread` holding an open libuv handle.** Before it bails out, the engine marks all objects as destructed, so `dtor_obj` never runs — and `Thread` released its event only from there. The cross-thread notify handle therefore survived reactor shutdown: `uv_loop_close()` returned `EBUSY`, the loop's internals and the persistent thread context leaked, and a debug build printed one "leftover libuv handle" line per thread. The release now also runs from `free_obj`, which the engine always calls.
+
 ## [0.9.0] - 2026-08-06
 
 ### Changed

--- a/tests/thread/081-thread_fatal_disposes_notify_handle.phpt
+++ b/tests/thread/081-thread_fatal_disposes_notify_handle.phpt
@@ -10,15 +10,14 @@ memory_limit=64M
 --FILE--
 <?php
 /*
- * Regression: php_error_cb marks every live object as destructed before it
- * bails out, so dtor_obj never runs for a Thread still held by a variable.
- * Thread released its event — and with it closed the uv_async notify handle —
- * only from dtor_obj, so after any fatal error those handles stayed open:
- * uv_loop_close returned EBUSY and the persistent thread context leaked.
+ * A fatal error bails out without dtor_obj, so a Thread still held by a
+ * variable must release its uv_async notify handle from free_obj. An open
+ * handle fails uv_loop_close() and leaks the persistent thread context.
  *
- * A debug build names every survivor on stderr ("leftover libuv handle"),
- * which run-tests folds into the compared output, so the bug appears as extra
- * lines behind the fatal error. Hence no trailing %A here.
+ * A debug build prints one "leftover libuv handle" line per survivor on
+ * stderr, and run-tests compares stderr together with stdout, so the leak
+ * appears as extra lines after the fatal error. No trailing %A for that
+ * reason: it would match them.
  */
 use function Async\spawn_thread;
 use function Async\await_all;
@@ -32,7 +31,7 @@ for ($i = 0; $i < 4; $i++) {
 await_all($threads);
 echo "threads joined\n";
 
-// $threads stays live: the Thread objects are still reachable at bailout.
+// $threads is never unset: the Thread objects must be reachable at bailout.
 $data = [];
 
 while (true) {

--- a/tests/thread/081-thread_fatal_disposes_notify_handle.phpt
+++ b/tests/thread/081-thread_fatal_disposes_notify_handle.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Thread: a fatal error disposes live Thread events (no leftover libuv notify handles)
+--SKIPIF--
+<?php
+if (!PHP_ZTS) die('skip ZTS required');
+if (!function_exists('Async\spawn_thread')) die('skip spawn_thread not available');
+?>
+--INI--
+memory_limit=64M
+--FILE--
+<?php
+/*
+ * Regression: php_error_cb marks every live object as destructed before it
+ * bails out, so dtor_obj never runs for a Thread still held by a variable.
+ * Thread released its event — and with it closed the uv_async notify handle —
+ * only from dtor_obj, so after any fatal error those handles stayed open:
+ * uv_loop_close returned EBUSY and the persistent thread context leaked.
+ *
+ * A debug build names every survivor on stderr ("leftover libuv handle"),
+ * which run-tests folds into the compared output, so the bug appears as extra
+ * lines behind the fatal error. Hence no trailing %A here.
+ */
+use function Async\spawn_thread;
+use function Async\await_all;
+
+$threads = [];
+
+for ($i = 0; $i < 4; $i++) {
+    $threads[] = spawn_thread(static fn() => bin2hex(random_bytes(8)));
+}
+
+await_all($threads);
+echo "threads joined\n";
+
+// $threads stays live: the Thread objects are still reachable at bailout.
+$data = [];
+
+while (true) {
+    $data[] = str_repeat('A', 1024 * 1024);
+}
+--EXPECTF--
+threads joined
+
+Fatal error: Allowed memory size of %d bytes exhausted%sin %s on line %d

--- a/thread.c
+++ b/thread.c
@@ -3033,9 +3033,9 @@ static void thread_object_free(zend_object *object)
 {
 	async_thread_object_t *thread = async_thread_object_from_obj(object);
 
-	/* php_error_cb() marks every object as destructed before a fatal bails out,
-	 * so dtor_obj never runs and free_obj is the last chance to dispose the
-	 * event. An undisposed one keeps its notify handle open, which fails
+	/* free_obj must dispose the event too: php_error_cb() marks every object
+	 * as destructed before a fatal bails out, so dtor_obj does not run at all.
+	 * An event left undisposed keeps its notify handle open, which fails
 	 * uv_loop_close() at reactor shutdown and leaks the thread context. */
 	if (thread->thread_event != NULL) {
 		zend_async_event_t *event = &thread->thread_event->base;
@@ -3046,7 +3046,6 @@ static void thread_object_free(zend_object *object)
 		}
 	}
 
-	/* Only the dtor dispatches the handlers: they are user code. */
 	if (thread->finally_handlers != NULL) {
 		zend_array_destroy(thread->finally_handlers);
 		thread->finally_handlers = NULL;

--- a/thread.c
+++ b/thread.c
@@ -3033,12 +3033,10 @@ static void thread_object_free(zend_object *object)
 {
 	async_thread_object_t *thread = async_thread_object_from_obj(object);
 
-	/* A fatal error skips dtor_obj entirely: php_error_cb marks every live
-	 * object as destructed before it bails out. The event would then keep its
-	 * libuv notify handle open past reactor shutdown (uv_loop_close => EBUSY)
-	 * and leak the persistent thread context, so dispose it here as well.
-	 * Dispatching finally handlers stays in the dtor — running user code on
-	 * the fatal path is not safe; here the array is only released. */
+	/* php_error_cb() marks every object as destructed before a fatal bails out,
+	 * so dtor_obj never runs and free_obj is the last chance to dispose the
+	 * event. An undisposed one keeps its notify handle open, which fails
+	 * uv_loop_close() at reactor shutdown and leaks the thread context. */
 	if (thread->thread_event != NULL) {
 		zend_async_event_t *event = &thread->thread_event->base;
 		thread->thread_event = NULL;
@@ -3048,6 +3046,7 @@ static void thread_object_free(zend_object *object)
 		}
 	}
 
+	/* Only the dtor dispatches the handlers: they are user code. */
 	if (thread->finally_handlers != NULL) {
 		zend_array_destroy(thread->finally_handlers);
 		thread->finally_handlers = NULL;

--- a/thread.c
+++ b/thread.c
@@ -3033,6 +3033,26 @@ static void thread_object_free(zend_object *object)
 {
 	async_thread_object_t *thread = async_thread_object_from_obj(object);
 
+	/* A fatal error skips dtor_obj entirely: php_error_cb marks every live
+	 * object as destructed before it bails out. The event would then keep its
+	 * libuv notify handle open past reactor shutdown (uv_loop_close => EBUSY)
+	 * and leak the persistent thread context, so dispose it here as well.
+	 * Dispatching finally handlers stays in the dtor — running user code on
+	 * the fatal path is not safe; here the array is only released. */
+	if (thread->thread_event != NULL) {
+		zend_async_event_t *event = &thread->thread_event->base;
+		thread->thread_event = NULL;
+
+		if (event->dispose != NULL) {
+			event->dispose(event);
+		}
+	}
+
+	if (thread->finally_handlers != NULL) {
+		zend_array_destroy(thread->finally_handlers);
+		thread->finally_handlers = NULL;
+	}
+
 	/* Release the scope ref captured at spawn time. This runs after the
 	 * dtor has finished (and after any delayed finally-handlers kept the
 	 * Thread alive via GC_ADDREF), so the scope outlives every handler


### PR DESCRIPTION
Closes #219.

`php_error_cb()` marks every live object as destructed before it bails out, so `dtor_obj` runs for none of them and teardown calls only `free_obj`. `thread_object_dtor()` was the sole caller of `event->dispose()`, and that dispose is the sole `uv_close()` of the cross-thread notify handle. After any fatal error the handle stayed open: `uv_loop_close()` returned `EBUSY`, and the loop's internals plus the persistent `zend_async_thread_context_t` leaked. A debug build reported one `leftover libuv handle` line per live thread.

`free_obj` now disposes the event too, and releases the finally-handler array. Dispatching those handlers stays in the dtor, since user code must not run on the fatal path.

Timers, sockets, signals and `ThreadPool` were checked on the same fatal path and release their handles already; only `Thread` was affected.

## Test

`tests/thread/081-thread_fatal_disposes_notify_handle.phpt` runs four threads, keeps them reachable and exhausts the memory limit. A debug build names each surviving handle on stderr, which run-tests folds into the compared output, so the leak shows up as extra lines behind the fatal error — hence no trailing `%A` in `--EXPECTF--`.

Verified by reverting the fix: the test then fails on exactly the four `leftover libuv handle` lines. Full local suite with the fix: 1228 tests, 0 failures.