### PR TITLE
tests: accept either attribution of the socket send warning

### DIFF
--- a/tests/curl/025-write_file_broken_pipe.phpt
+++ b/tests/curl/025-write_file_broken_pipe.phpt
@@ -46,7 +46,7 @@ async_test_server_stop($server);
 echo "Done\n";
 ?>
 --EXPECTF--
-Warning: Unknown: Send of %d bytes failed with errno=%d %s in Unknown on line 0
+Warning: %sSend of %d bytes failed with errno=%d %s in %s on line %d
 curl_exec returned: false
 errno: 23
 is write error: yes

--- a/tests/curl/054-multi_write_file_broken_pipe.phpt
+++ b/tests/curl/054-multi_write_file_broken_pipe.phpt
@@ -60,7 +60,7 @@ async_test_server_stop($server);
 echo "Done\n";
 ?>
 --EXPECTF--
-Warning: Unknown: Send of %d bytes failed with errno=%d %s in Unknown on line 0
+Warning: %sSend of %d bytes failed with errno=%d %s in %s on line %d
 Transfer result: CURLE_WRITE_ERROR
 curl_errno: CURLE_WRITE_ERROR
 Done


### PR DESCRIPTION
`ALPINE_X64_DEBUG_ZTS` failed in the OpCache step of run [31670068168](https://github.com/true-async/php-async/actions/runs/31670068168) on `tests/curl/054-multi_write_file_broken_pipe.phpt`:

```
- Warning: Unknown: Send of %d bytes failed with errno=%d %s in Unknown on line 0
+ Warning: curl_multi_exec(): Send of 10000 bytes failed with errno=32 Broken pipe in %s054-multi_write_file_broken_pipe.php on line 26
```

The write into the closed pipe runs either inside `curl_multi_exec()` or from the event loop while the coroutine waits in `curl_multi_select()`. `php_error_docref()` names the active internal function when there is one and falls back to `Unknown` and line 0 when there is none, so both forms are correct and which one appears depends on when the transfer delivers its body. Both tests pinned the second form.

The pattern now accepts either. `025-write_file_broken_pipe.phpt` carries the same line and the same exposure, so it changes too.

Checked on the local build: both tests pass plain, with `opcache.enable_cli=1`, and with `opcache.jit=tracing`. The two other red tests in `tests/curl` (`063`, `064`) fail only through the `ext/async` symlink, where `../../../../ext/curl/tests/server.inc` does not resolve; they are green in CI.