### PR TITLE
fix(thread-pool): report a bootloader failure through the worker's error stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Async extension for PHP will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **A `ThreadPool` bootloader that threw was never reported.** The worker kept the message for a later `submit()` and rejected the tasks already queued; that was its only trace. A pool driven as a set of long-lived workers reads neither channel — an HTTP server submits one task per worker and awaits it only for completion — so the exception was lost, and a bootloader that failed on its first `require` looked like a pool that started and did nothing. The worker now reports the exception through its own error stream, so `display_errors`, `log_errors` and `error_log` apply, and then closes the pool and rejects the queued tasks as before.
+
 ## [0.9.1] - 2026-08-11
 
 ### Fixed

--- a/tests/thread_pool/063-bootloader_exception.phpt
+++ b/tests/thread_pool/063-bootloader_exception.phpt
@@ -28,5 +28,9 @@ spawn(function() {
     $pool->close();
 });
 ?>
---EXPECT--
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: boot failed! in %s:%d
+Stack trace:
+%A
+  thrown in %s on line %d
 boot failed!

--- a/tests/thread_pool/080-bootloader_exception_reported.phpt
+++ b/tests/thread_pool/080-bootloader_exception_reported.phpt
@@ -1,0 +1,35 @@
+--TEST--
+ThreadPool: a bootloader that throws is reported through the worker's error stream with nothing submitted
+--SKIPIF--
+<?php
+if (!PHP_ZTS) die('skip ZTS required');
+if (!class_exists('Async\ThreadPool')) die('skip ThreadPool not available');
+?>
+--FILE--
+<?php
+
+use Async\ThreadPool;
+use function Async\spawn;
+
+// Task rejection is the pool's other channel for a failed bootloader, and a
+// pool driven as a set of long-lived workers (an HTTP server) never reads it:
+// nothing is submitted here at all. The failure must still reach display_errors
+// and error_log the way any uncaught exception does, or the pool dies mute.
+spawn(function() {
+    $boot = function() { throw new \RuntimeException("boot failed!"); };
+    $pool = new ThreadPool(1, 0, $boot);
+
+    // The failing worker closes the pool; bounded so a regression fails the
+    // test on output rather than hanging until the harness timeout.
+    for ($i = 0; $i < 200 && !$pool->isClosed(); $i++) {
+        \Async\delay(10);
+    }
+
+    $pool->close();
+});
+?>
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: boot failed! in %s:%d
+Stack trace:
+%A
+  thrown in %s on line %d

--- a/thread_pool.c
+++ b/thread_pool.c
@@ -106,6 +106,27 @@ static zend_object *thread_pool_wrap_transfer_error(zend_object *src)
 		(msg != NULL && Z_TYPE_P(msg) == IS_STRING) ? Z_STRVAL_P(msg) : "thread transfer failed");
 }
 
+/* Report the bootloader's uncaught exception through this worker's own error
+ * stream — display_errors and error_log, the same route an uncaught exception
+ * takes in any other request — and consume EG(exception).
+ *
+ * The rejection of pending tasks is the pool's only other channel for a failed
+ * bootloader, and it reaches nobody when the pool serves as a set of long-lived
+ * workers (an HTTP server submits one task per worker and never awaits it) or
+ * when the failure happens before anything is submitted. Without this the whole
+ * pool dies with no diagnostic at all. */
+static void thread_pool_report_boot_failure(void)
+{
+	if (EG(exception) == NULL) {
+		return;
+	}
+
+	/* E_ERROR is reported, not raised: zend_exception_error adds E_DONT_BAIL,
+	 * so the worker keeps running and reaches the reject/close path below. */
+	zend_exception_error(EG(exception), E_ERROR);
+	zend_clear_exception();
+}
+
 /* task_channel is swapped by reload() and read cross-thread on bailout paths —
  * always go through the atomic load. */
 #define POOL_TASK_CHANNEL(pool) \
@@ -242,7 +263,7 @@ static void thread_pool_worker_handler(zend_async_thread_event_t *event, void *c
 				 * as a clean transfer exception (the raw Error's backtrace reaches
 				 * into worker-local load state and crashes the awaiter if copied). */
 				zend_object *boot_ex = thread_pool_wrap_transfer_error(EG(exception));
-				zend_clear_exception();
+				thread_pool_report_boot_failure();
 				zval_ptr_dtor(&boot_callable);
 				thread_pool_record_bootloader_error(pool, boot_ex);
 				thread_pool_close(pool);
@@ -269,7 +290,9 @@ static void thread_pool_worker_handler(zend_async_thread_event_t *event, void *c
 				/* Bootloader called exit()/die() (unwind-exit token) or hit a fatal
 				 * error (bailout). Convert into a transfer exception for every
 				 * pending task instead of leaking the token through reject or
-				 * re-raising zend_bailout(), either of which crashes the worker fiber. */
+				 * re-raising zend_bailout(), either of which crashes the worker fiber.
+				 * Nothing is reported here: a fatal error printed itself on the way
+				 * to the bailout, and exit() is not an error. */
 				if (EG(exception) != NULL) {
 					zend_clear_exception();
 				}
@@ -286,7 +309,9 @@ static void thread_pool_worker_handler(zend_async_thread_event_t *event, void *c
 				 * pending task's awaiter instead of a generic cancellation. */
 				zend_object *boot_ex = EG(exception);
 				GC_ADDREF(boot_ex);
-				zend_clear_exception();
+				/* Takes over the reference EG(exception) held; ours keeps boot_ex
+				 * alive for the reject below. */
+				thread_pool_report_boot_failure();
 				thread_pool_record_bootloader_error(pool, boot_ex);
 				thread_pool_close(pool);
 				thread_pool_drain_tasks(pool, true, boot_ex);


### PR DESCRIPTION
A `ThreadPool` bootloader that throws had two ways out of the worker, and both are private to whoever submits tasks: the message is kept for the next `submit()`, and the tasks already queued are rejected with the exception. A pool driven as a set of long-lived workers reads neither. The HTTP server submits one internal task per worker and awaits it only for completion, so the exception was dropped and the process exited 0 with nothing on stdout, nothing in `error_log`, and no worker ever having served.

The worker now hands the exception to `zend_exception_error()` before it closes the pool. That is the same call the engine makes for an uncaught exception at the end of a request, so `display_errors`, `log_errors`, `error_log` and `error_reporting` all apply, and the output reads as usual:

```
PHP Fatal error:  Uncaught RuntimeException: boot failed! in /app/boot.php:12
```

`zend_exception_error()` adds `E_DONT_BAIL`, so the worker still reaches the close-and-reject path and every existing consumer sees what it saw before. `set_exception_handler()` is not invoked: the exception is reported, not dispatched.

The bailout branch (`exit()` in the bootloader, or a fatal error) keeps its silence — a fatal error has already printed itself on the way to the bailout, and `exit()` is not an error.

## Tests

`080-bootloader_exception_reported.phpt` is new: a pool whose bootloader throws, with nothing submitted at all, must still produce the fatal. `063-bootloader_exception.phpt` keeps its assertion that the message reaches the awaiter and now also expects the report.

Locally: `ext/async`, 1230 tests, 3 failures — `curl/063`, `curl/064`, `io/082`. None of them creates a `ThreadPool`, so this change cannot run in them.
