### PR TITLE
fix(reactor): wait for the Windows process watcher before freeing what it reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Async extension for PHP will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **A script that ran child processes could die with an access violation on Windows after its work was done.** The reactor watches child processes on a dedicated thread; retiring that watcher detached it and then closed its completion port and freed the queue it pushes into, so a watcher caught mid-push wrote into released memory. The exit code was `0xC0000005` and the output was complete, which made it read as a shutdown crash with no cause. The watcher is now woken and waited for before any of that is released. Two ways it outlived the reactor go with the fix: a process event that ends by cancellation or dispose now gives its descriptor back like one that ends by an exit packet, and reactor shutdown retires the watcher outright. Measured on `run-tests -j4` over `tests/exec` and `tests/io`: 5 crashes in 10 runs before, 0 in 20 after.
+
 ## [0.9.2] - 2026-08-13
 
 ### Fixed

--- a/async.c
+++ b/async.c
@@ -1726,7 +1726,7 @@ static PHP_GINIT_FUNCTION(async)
 	async_globals->watcherThread = NULL;
 	async_globals->ioCompletionPort = NULL;
 	async_globals->countWaitingDescriptors = 0;
-	async_globals->isRunning = false;
+	zend_atomic_bool_init(&async_globals->isRunning, false);
 	async_globals->uvloop_wakeup = NULL;
 	async_globals->pid_queue = NULL;
 #endif

--- a/libuv_reactor.c
+++ b/libuv_reactor.c
@@ -83,6 +83,9 @@ static void libuv_signal_close_cb(uv_handle_t *handle);
 static void libuv_cleanup_signal_handlers(void);
 static void libuv_cleanup_signal_events(void);
 static void libuv_cleanup_process_events(void);
+#ifdef PHP_WIN32
+static void libuv_stop_process_watcher(void);
+#endif
 static void uv_stat_to_zend_stat(const uv_stat_t *uv_statbuf, zend_stat_t *zend_statbuf);
 
 ///////////////////////////////////////////////////////////
@@ -1819,6 +1822,13 @@ static void libuv_cleanup_process_events(void)
 		zend_array_destroy(ASYNC_G(process_events));
 		ASYNC_G(process_events) = NULL;
 	}
+
+#ifdef PHP_WIN32
+	/* Belt for the descriptor count: an event released without passing through
+	 * stop() would leave the watcher running, and the thread outliving the
+	 * globals it reads is a crash at shutdown rather than a leak. */
+	libuv_stop_process_watcher();
+#endif
 }
 
 /* }}} */
@@ -1834,7 +1844,7 @@ static void process_watcher_thread(void *args)
 
 	ULONG_PTR completionKey;
 
-	while (reactor->isRunning && reactor->ioCompletionPort != NULL) {
+	while (zend_atomic_bool_load(&reactor->isRunning) && reactor->ioCompletionPort != NULL) {
 
 		DWORD lpNumberOfBytesTransferred;
 		// OVERLAPPED overlapped = {0};
@@ -1850,7 +1860,7 @@ static void process_watcher_thread(void *args)
 			continue;
 		}
 
-		if (reactor->isRunning == false) {
+		if (zend_atomic_bool_load(&reactor->isRunning) == false) {
 			break;
 		}
 
@@ -1874,12 +1884,12 @@ static void process_watcher_thread(void *args)
 
 			unsigned int delay = 1;
 
-			while (reactor->isRunning && circular_buffer_is_full(reactor->pid_queue)) {
+			while (zend_atomic_bool_load(&reactor->isRunning) && circular_buffer_is_full(reactor->pid_queue)) {
 				usleep(delay);
 				delay = MIN(delay << 1, 1000);
 			}
 
-			if (false == reactor->isRunning) {
+			if (false == zend_atomic_bool_load(&reactor->isRunning)) {
 				break;
 			}
 		}
@@ -1910,14 +1920,12 @@ static void on_process_event(uv_async_t *handle)
 
 		process_event->event.exit_code = exit_code;
 
-		if (reactor->countWaitingDescriptors > 0) {
-			reactor->countWaitingDescriptors--;
-
-			if (reactor->countWaitingDescriptors == 0) {
-				libuv_stop_process_watcher();
-			}
-		}
-
+		/* stop() below gives the descriptor back — it is the one place that retires
+		 * a process event, whichever way the event ends, so a cancelled or disposed
+		 * one retires the watcher too. The order carries weight: a callback that
+		 * starts a new process claims its descriptor before this one is given back,
+		 * so the count cannot reach zero between the two and the watcher is not
+		 * stopped and started again underneath it. */
 		ZEND_ASYNC_CALLBACKS_NOTIFY(&process_event->event.base, NULL, NULL);
 		process_event->event.base.stop(&process_event->event.base);
 		IF_EXCEPTION_STOP_REACTOR;
@@ -1948,7 +1956,7 @@ static void libuv_start_process_watcher(void)
 		return;
 	}
 
-	reactor->isRunning = true;
+	zend_atomic_bool_store(&reactor->isRunning, true);
 	reactor->countWaitingDescriptors = 0;
 
 	int error = uv_thread_create(thread, process_watcher_thread, reactor);
@@ -1956,7 +1964,7 @@ static void libuv_start_process_watcher(void)
 	if (error < 0) {
 		uv_thread_detach(thread);
 		pefree(thread, 0);
-		reactor->isRunning = false;
+		zend_atomic_bool_store(&reactor->isRunning, false);
 		php_error_docref(NULL, E_CORE_ERROR, "Failed to create process watcher thread: %s", uv_strerror(error));
 		return;
 	}
@@ -1969,10 +1977,26 @@ static void libuv_start_process_watcher(void)
 	circular_buffer_ctor(reactor->pid_queue, 64, sizeof(async_process_event_t *), NULL);
 
 	if (error < 0) {
-		uv_thread_detach(thread);
-		reactor->isRunning = false;
+		/* The watcher is already blocked on the port. Clearing WATCHER leaves
+		 * nothing that could ever retire it, so it has to be woken and waited for
+		 * here — a detached thread reading these globals outlives them. */
+		zend_atomic_bool_store(&reactor->isRunning, false);
+		PostQueuedCompletionStatus(reactor->ioCompletionPort, 0, (ULONG_PTR) 0, NULL);
+		uv_thread_join(thread);
 		pefree(thread, 0);
 		WATCHER = NULL;
+
+		CloseHandle(reactor->ioCompletionPort);
+		reactor->ioCompletionPort = NULL;
+
+		/* uv_async_init failed, so the handle carries no loop state: it is plain
+		 * memory here, not something uv_close may touch. */
+		pefree(reactor->uvloop_wakeup, 0);
+		reactor->uvloop_wakeup = NULL;
+
+		circular_buffer_destroy(reactor->pid_queue);
+		reactor->pid_queue = NULL;
+
 		php_error_docref(NULL, E_CORE_ERROR, "Failed to initialize async handle: %s", uv_strerror(error));
 	}
 }
@@ -1991,16 +2015,28 @@ static void libuv_stop_process_watcher(void)
 
 	LIBUV_REACTOR_VAR;
 
-	reactor->isRunning = false;
+	zend_atomic_bool_store(&reactor->isRunning, false);
+
+	/* The watcher may sit anywhere in its loop — between the isRunning check and
+	 * circular_buffer_push, or on its way to uv_async_send — so the queue, the
+	 * wakeup handle and the port stay alive until it has left. The packet posted
+	 * here is what releases it from GetQueuedCompletionStatus. */
+	if (UNEXPECTED(!PostQueuedCompletionStatus(reactor->ioCompletionPort, 0, (ULONG_PTR) 0, NULL))) {
+		/* Nothing will wake the watcher now, and a join would hold the loop thread
+		 * for the life of the process. It keeps its port, its queue and its wakeup
+		 * handle instead: a leak the process ends, rather than a hang. */
+		uv_thread_detach(WATCHER);
+		pefree(WATCHER, 0);
+		WATCHER = NULL;
+		return;
+	}
+
+	uv_thread_join(WATCHER);
+	pefree(WATCHER, 0);
+	WATCHER = NULL;
 
 	uv_close((uv_handle_t *) reactor->uvloop_wakeup, libuv_wakeup_close_cb);
 	reactor->uvloop_wakeup = NULL;
-
-	// send wake up event to stop the thread
-	PostQueuedCompletionStatus(reactor->ioCompletionPort, 0, (ULONG_PTR) 0, NULL);
-	uv_thread_detach(WATCHER);
-	pefree(WATCHER, 0);
-	WATCHER = NULL;
 
 	// Stop IO completion port
 	CloseHandle(reactor->ioCompletionPort);
@@ -2103,6 +2139,18 @@ static bool libuv_process_event_stop(zend_async_event_t *event)
 	if (process->hJob != NULL) {
 		CloseHandle(process->hJob);
 		process->hJob = NULL;
+	}
+
+	/* Counterpart of the increment in start(): the last event to go retires the
+	 * watcher thread. The prologue above returns early for an event already
+	 * closed, so this runs once per event however it ends — exit packet,
+	 * cancellation or shutdown. */
+	if (LIBUV_REACTOR->countWaitingDescriptors > 0) {
+		LIBUV_REACTOR->countWaitingDescriptors--;
+
+		if (LIBUV_REACTOR->countWaitingDescriptors == 0) {
+			libuv_stop_process_watcher();
+		}
 	}
 
 	ZEND_ASYNC_DECREASE_EVENT_COUNT(event);

--- a/libuv_reactor.c
+++ b/libuv_reactor.c
@@ -1824,9 +1824,9 @@ static void libuv_cleanup_process_events(void)
 	}
 
 #ifdef PHP_WIN32
-	/* Belt for the descriptor count: an event released without passing through
-	 * stop() would leave the watcher running, and the thread outliving the
-	 * globals it reads is a crash at shutdown rather than a leak. */
+	/* The descriptor count is the usual way the watcher is retired; this is the
+	 * last one. An event released without passing through stop() leaves the count
+	 * above zero, and a watcher that outlives these globals reads freed memory. */
 	libuv_stop_process_watcher();
 #endif
 }
@@ -1920,12 +1920,9 @@ static void on_process_event(uv_async_t *handle)
 
 		process_event->event.exit_code = exit_code;
 
-		/* stop() below gives the descriptor back — it is the one place that retires
-		 * a process event, whichever way the event ends, so a cancelled or disposed
-		 * one retires the watcher too. The order carries weight: a callback that
-		 * starts a new process claims its descriptor before this one is given back,
-		 * so the count cannot reach zero between the two and the watcher is not
-		 * stopped and started again underneath it. */
+		/* Notify before stop(): a callback that starts a process takes its
+		 * descriptor before this event gives its own back, so the count never
+		 * passes through zero and the watcher is not stopped and started again. */
 		ZEND_ASYNC_CALLBACKS_NOTIFY(&process_event->event.base, NULL, NULL);
 		process_event->event.base.stop(&process_event->event.base);
 		IF_EXCEPTION_STOP_REACTOR;
@@ -2019,12 +2016,12 @@ static void libuv_stop_process_watcher(void)
 
 	/* The watcher may sit anywhere in its loop — between the isRunning check and
 	 * circular_buffer_push, or on its way to uv_async_send — so the queue, the
-	 * wakeup handle and the port stay alive until it has left. The packet posted
-	 * here is what releases it from GetQueuedCompletionStatus. */
+	 * wakeup handle and the port are released only after it has left. The packet
+	 * posted here is what returns it from GetQueuedCompletionStatus. */
 	if (UNEXPECTED(!PostQueuedCompletionStatus(reactor->ioCompletionPort, 0, (ULONG_PTR) 0, NULL))) {
-		/* Nothing will wake the watcher now, and a join would hold the loop thread
+		/* Nothing can wake the watcher now, so a join would hold the loop thread
 		 * for the life of the process. It keeps its port, its queue and its wakeup
-		 * handle instead: a leak the process ends, rather than a hang. */
+		 * handle, which leak until the process exits. */
 		uv_thread_detach(WATCHER);
 		pefree(WATCHER, 0);
 		WATCHER = NULL;

--- a/php_async.h
+++ b/php_async.h
@@ -17,6 +17,7 @@
 #define PHP_ASYNC_H
 
 #include <php.h>
+#include <Zend/zend_atomic.h>
 
 #ifdef PHP_WIN32
 #include "libuv/uv.h"
@@ -112,7 +113,11 @@ HashTable *process_events;  /* dedicated for SIGCHLD process events */
 uv_thread_t *watcherThread;
 HANDLE ioCompletionPort;
 unsigned int countWaitingDescriptors;
-bool isRunning;
+/* Read by the watcher thread on every turn of its loop and written by the reactor
+ * thread that retires it, with no lock between them: the store has to reach the
+ * watcher, or the join in libuv_stop_process_watcher (libuv_reactor.c) waits for
+ * a thread that never leaves. */
+zend_atomic_bool isRunning;
 uv_async_t *uvloop_wakeup;
 /* Circular buffer of libuv_process_t ptr */
 circular_buffer_t *pid_queue;


### PR DESCRIPTION
Windows CI has been failing intermittently with `Termsig=-1073741819` — `STATUS_ACCESS_VIOLATION` — in tests that spawn processes, always after the test had printed its expected output. The crash is at shutdown, and the run-tests diff says nothing about where.

`libuv_stop_process_watcher` detached the watcher thread and then, in the next three statements, closed the IO completion port, closed the wakeup handle and destroyed `pid_queue`. The watcher can sit anywhere in its loop — between the `isRunning` check and `circular_buffer_push`, or on its way to `uv_async_send` — so the reactor was releasing memory under a live thread about to write into it.

The stop now posts its wake-up packet, joins the watcher, and releases everything afterwards. `isRunning` becomes `zend_atomic_bool`, since the join depends on that store reaching the other thread. A post that fails falls back to detaching and leaks the port and the queue rather than hanging the loop thread on a watcher nothing can wake.

Two ways the watcher outlived the reactor are closed with it, both of which left a thread reading globals that were gone:

- the descriptor count is given back in `libuv_process_event_stop` alone, so an event that ends by cancellation or dispose retires the watcher exactly as an exit packet does — before, only a popped exit packet decremented, and anything else counted forever;
- `libuv_cleanup_process_events` retires the watcher outright, and so does the error path of `uv_async_init`, which used to detach a thread already blocked on the port and then clear the handle that was the only way to reach it.

## Evidence

The crash needs the suite's parallelism: 0 failures in 40 runs of `tests/exec/011` alone, on both the current engine and the one from before the CI window. Under `run-tests -j4` over `tests/exec` and `tests/io` it reproduces at will.

| | failures |
|---|---|
| before | 5 in 10 |
| after | 0 in 20 |

Same command, same php-src (`true-async-stable`), same runner image, through the `Debug Windows crash` workflow added for this hunt. Failing tests before the fix: `exec/001`, `exec/003`, `exec/011`, `io/014` — every one of them spawns processes.

No new test: the four above are the reproduction, and they already fail without this change.

The defect is old. `libuv_stop_process_watcher` last changed on 2026-02-22 and the structure dates to the initial commit, so this is not a regression of 0.9.1 or 0.9.2 — the recent engine merge only shifted the timing enough to surface it.
