### PR TITLE
#235 Pool: reserve a released resource for the waiter it wakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A coroutine that acquires and releases a pool resource in a loop starved every other one.** `release()` woke a waiter and pushed the resource into the shared idle buffer, but a wakeup only queues the coroutine: the releasing one kept running and took its own slot back before the woken waiter ever ran, so parked coroutines were served only when a holder left its loop for good — the 10-60 s latency outliers reported under `PDO::ATTR_POOL_ENABLED` with per-query release. A released resource is now reserved for the waiter it wakes, and no other coroutine may take it until that waiter runs. Measured with 16 coroutines over `max: 5`: the last one waited 663 ms for its first acquire before, 3 ms after.
+- **A waiter cancelled before its wakeup ran left the pool deadlocked with an idle resource.** The wakeup went to one waiter and to it alone, so a cancellation or a timeout arriving before it ran left the resource idle with no waiter assigned and the rest parked with no wakeup coming — `Async\DeadlockError` on a live pool reporting `idle=1`. A waiter that leaves without its place now hands the reservation on, whether the place was a resource or the capacity to create one, and whether it leaves through a cancellation, a timeout or an open circuit breaker.
+- **Waiters were not served in arrival order.** Removing a waiter moved the last element of the queue into the freed head, so the newest waiter was served second and the ones in the middle stalled. Removal now shifts the tail.
+- **`Pool::release()` freed the caller's own reference to the resource.** When `beforeRelease` rejected the resource, or when the pool was already closed, the destroy path dropped a reference it had never taken, so the variable the caller had just passed in was freed under it — a use-after-free that showed up as `zend_mm_heap corrupted`. The pool now takes a reference of its own before destroying.
+- **A pool with queued waiters kept its surplus idle resources unusable.** With one coroutine queued, `acquire()` and `tryAcquire()` refused every idle resource, including the ones reserved for nobody. The pool now counts reserved places and gives out only the surplus. Deadlock reports include the count: `Pool(idle=1, active=0, reserved=1, max=1)`.
+
 ## [0.9.4] - 2026-08-15
 
 ### Added

--- a/pool.c
+++ b/pool.c
@@ -87,28 +87,41 @@ static void pool_queue_push(zend_async_callbacks_vector_t *queue, zend_async_poo
 	queue->data[queue->length++] = (zend_async_event_callback_t *) waiter;
 }
 
-static zend_async_pool_waiter_t *pool_queue_pop(zend_async_callbacks_vector_t *queue)
-{
-	if (queue->length == 0) {
-		return NULL;
-	}
-	zend_async_pool_waiter_t *waiter = (zend_async_pool_waiter_t *) queue->data[0];
-	queue->length--;
-	/* Swap with last element - O(1) */
-	queue->data[0] = queue->data[queue->length];
-	return waiter;
-}
-
+/* Arrival order is the service order: swapping the last element into the hole
+ * would serve the newest waiter first. */
 static bool pool_queue_remove(zend_async_callbacks_vector_t *queue, zend_async_pool_waiter_t *waiter)
 {
 	for (uint32_t i = 0; i < queue->length; i++) {
 		if (queue->data[i] == (zend_async_event_callback_t *) waiter) {
 			queue->length--;
-			queue->data[i] = queue->data[queue->length];
+			memmove(queue->data + i,
+					queue->data + i + 1,
+					(queue->length - i) * sizeof(zend_async_event_callback_t *));
 			return true;
 		}
 	}
 	return false;
+}
+
+/* Ignores arrival order; only for callers that drain the whole queue. */
+static zend_async_pool_waiter_t *pool_queue_pop_last(zend_async_callbacks_vector_t *queue)
+{
+	if (queue->length == 0) {
+		return NULL;
+	}
+	return (zend_async_pool_waiter_t *) queue->data[--queue->length];
+}
+
+/* Oldest waiter with no reservation, or NULL when every waiter has one. */
+static zend_async_pool_waiter_t *pool_queue_first_unreserved(zend_async_callbacks_vector_t *queue)
+{
+	for (uint32_t i = 0; i < queue->length; i++) {
+		zend_async_pool_waiter_t *waiter = (zend_async_pool_waiter_t *) queue->data[i];
+		if (!waiter->reserved) {
+			return waiter;
+		}
+	}
+	return NULL;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -184,6 +197,15 @@ static void pool_destroy_resource(async_pool_t *pool, zval *resource)
 	}
 
 	zval_ptr_dtor(resource);
+}
+
+/* release() borrows its argument and pool_destroy_resource drops a reference:
+ * take one of our own, or the caller's variable is freed out from under it. */
+static void pool_destroy_borrowed_resource(async_pool_t *pool, zval *resource)
+{
+	zval owned;
+	ZVAL_COPY(&owned, resource);
+	pool_destroy_resource(pool, &owned);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -398,7 +420,17 @@ static void pool_strategy_report_failure(async_pool_t *pool, zend_object *error)
 // Wait/Wake operations (like channel)
 ///////////////////////////////////////////////////////////////////////////////
 
-static void pool_wait_for_resource(async_pool_t *pool, zend_long timeout_ms)
+static bool pool_wake_waiter(async_pool_t *pool);
+
+/**
+ * Parks the current coroutine until the pool has an idle resource or free
+ * capacity for it.
+ *
+ * Returns true when the pool reserved a place for this waiter, which only it
+ * may take; false on timeout, cancellation and pool close. A caller that
+ * returns without taking a reserved place must wake the next waiter.
+ */
+static bool pool_wait_for_resource(async_pool_t *pool, zend_long timeout_ms)
 {
 	zend_async_pool_t *base = &pool->base;
 	zend_async_pool_waiter_t *waiter = ecalloc(1, sizeof(zend_async_pool_waiter_t));
@@ -422,35 +454,65 @@ static void pool_wait_for_resource(async_pool_t *pool, zend_long timeout_ms)
 
 	ZEND_ASYNC_SUSPEND();
 
+	const bool had_reservation = waiter->reserved;
+
 	/* Cleanup after waking up */
 	if (pool_queue_remove(&pool->waiters, waiter)) {
-		/* Was still in queue (timeout/close case) - release queue's ref */
+		/* Was still in queue (every path but pool close) - release queue's ref */
 		ZEND_ASYNC_EVENT_CALLBACK_RELEASE(&waiter->callback.base);
 	}
+
+	if (had_reservation) {
+		/* Spent by the caller's retry after we return, or handed on below. */
+		ZEND_ASSERT(pool->reserved_count > 0 && "A reservation was consumed twice");
+		pool->reserved_count--;
+	}
+
+	/* An unspent reservation would leave an idle resource or free capacity with
+	 * no waiter assigned, and nothing else wakes the queue afterwards. */
+	if (had_reservation && UNEXPECTED(EG(exception)) && !ZEND_ASYNC_POOL_IS_CLOSED(pool)) {
+		pool_wake_waiter(pool);
+	}
+
 	/* Release our initial ref */
 	ZEND_ASYNC_EVENT_CALLBACK_RELEASE(&waiter->callback.base);
+
+	return had_reservation;
 }
 
+/**
+ * Reserves an idle resource or free capacity for the oldest waiter without one
+ * and queues its resumption. Returns false when every waiter already holds a
+ * reservation, or when nobody waits.
+ *
+ * The waiter stays in the queue on purpose: until it runs, reserved_count is
+ * what stops any other coroutine — the releasing one included — from taking
+ * the place reserved for it.
+ */
 static bool pool_wake_waiter(async_pool_t *pool)
 {
-	zend_async_pool_t *base = &pool->base;
-	zend_async_pool_waiter_t *waiter = pool_queue_pop(&pool->waiters);
+	zend_async_pool_waiter_t *waiter = pool_queue_first_unreserved(&pool->waiters);
 	if (waiter == NULL) {
 		return false;
 	}
 
-	base->event.del_callback(&base->event, &waiter->callback.base);
-	waiter->callback.base.callback(&base->event, &waiter->callback.base, NULL, NULL);
-	ZEND_ASYNC_EVENT_CALLBACK_RELEASE(&waiter->callback.base);
+	/* The event callback stays registered; the waker's event cleanup drops it
+	 * on resume. */
+	ZEND_ASSERT(!waiter->reserved && "pool_queue_first_unreserved returned a reserved waiter");
+	waiter->reserved = true;
+	pool->reserved_count++;
+	waiter->callback.base.callback(&pool->base.event, &waiter->callback.base, NULL, NULL);
 
 	return true;
 }
 
+/* Drains the queue from the tail: order does not matter when every waiter gets
+ * the same exception, and head removal would shift the rest each time. */
 static void pool_wake_all_with_exception(async_pool_t *pool, zend_object *exception)
 {
 	zend_async_pool_t *base = &pool->base;
 	zend_async_pool_waiter_t *waiter;
-	while ((waiter = pool_queue_pop(&pool->waiters)) != NULL) {
+	while ((waiter = pool_queue_pop_last(&pool->waiters)) != NULL) {
 		base->event.del_callback(&base->event, &waiter->callback.base);
 		waiter->callback.base.callback(&base->event, &waiter->callback.base, NULL, exception);
 		ZEND_ASYNC_EVENT_CALLBACK_RELEASE(&waiter->callback.base);
@@ -529,10 +591,12 @@ static zend_string *pool_info(zend_async_event_t *event)
 {
 	const async_pool_t *pool = (async_pool_t *) event;
 
+	/* Without reserved, idle > 0 with coroutines queued reads as a lost wakeup. */
 	return zend_strpprintf(0,
-						   "Pool(idle=%zu, active=%u, max=%u)",
+						   "Pool(idle=%zu, active=%u, reserved=%u, max=%u)",
 						   circular_buffer_count(&pool->idle),
 						   pool->active_count,
+						   pool->reserved_count,
 						   pool->base.max_size);
 }
 
@@ -635,7 +699,8 @@ static void pool_healthcheck_timer_callback(zend_async_event_t *timer_event,
 			break;
 		}
 
-		/* The check yields: keep the resource counted while it is out. */
+		/* During the hook the resource is neither idle nor active, and the hook is
+		 * PHP code that may inspect the pool: count it as active. */
 		pool->active_count++;
 
 		bool is_healthy = pool_call_healthcheck(pool, &resource);
@@ -667,12 +732,19 @@ static void pool_healthcheck_timer_callback(zend_async_event_t *timer_event,
 				if (pool_create_resource(pool, &new_resource)) {
 					zval_circular_buffer_push(&pool->idle, &new_resource, true);
 					zval_ptr_dtor(&new_resource);
-				} else if (UNEXPECTED(EG(exception))) {
+					continue;
+				}
+
+				if (UNEXPECTED(EG(exception))) {
 					break;
 				}
 			}
 		}
 	}
+
+	/* Destroying a resource frees capacity and no release follows to report it.
+	 * Placed after the loop to cover the exits a throwing hook takes. */
+	pool_wake_waiter(pool);
 }
 
 static void pool_start_healthcheck_timer(async_pool_t *pool)
@@ -840,24 +912,32 @@ async_pool_t *zend_async_pool_create_internal(zend_async_pool_factory_fn factory
 bool zend_async_pool_acquire(async_pool_t *pool, zval *result, zend_long timeout_ms)
 {
 	const zend_async_pool_t *base = &pool->base;
+	/* Set when the last wakeup reserved a resource or capacity for this one. */
+	bool has_reservation = false;
 
 retry:
 	/* 1. Closed? */
 	if (ZEND_ASYNC_POOL_IS_CLOSED(pool)) {
 		zend_throw_exception(async_ce_pool_exception, "Pool is closed", 0);
-		return false;
+		goto give_up;
 	}
 
 	/* 2. Circuit breaker check */
 	if (base->circuit_state == ZEND_ASYNC_CIRCUIT_STATE_INACTIVE) {
 		async_throw_service_unavailable("Service is unavailable (circuit breaker is open)");
-		return false;
+		goto give_up;
 	}
 
+	/* Take only what is reserved for nobody, or what is reserved for us. Without
+	 * the rule a coroutine that releases and re-acquires takes back the slot its
+	 * own release just handed to a parked waiter. */
+	const bool may_serve_self = has_reservation || ASYNC_POOL_UNRESERVED(pool) > 0;
+
 	/* 2. Have idle resource? */
-	if (!circular_buffer_is_empty(&pool->idle)) {
+	if (!circular_buffer_is_empty(&pool->idle) && may_serve_self) {
 		zval resource;
 		zval_circular_buffer_pop(&pool->idle, &resource);
+		has_reservation = false;
 
 		/* Reserve before beforeAcquire: it may yield, and until then the
 		 * resource is in neither idle nor active_count. */
@@ -869,7 +949,7 @@ retry:
 			pool->active_count--;
 			pool_destroy_resource(pool, &resource);
 			if (UNEXPECTED(EG(exception))) {
-				/* Capacity freed: a waiter would never be woken otherwise. */
+				/* Capacity freed: no other path wakes a waiter for it. */
 				pool_wake_waiter(pool);
 				return false;
 			}
@@ -881,9 +961,11 @@ retry:
 	}
 
 	/* 3. Can create new? Reserve slot BEFORE factory call — factory may yield,
-	 * allowing other coroutines to pass the same check concurrently. */
+	 * allowing other coroutines to pass the same check concurrently. Capacity is
+	 * reserved for waiters the same way an idle resource is. */
 	const uint32_t total = ASYNC_POOL_TOTAL(pool);
-	if (total < base->max_size) {
+	if (total < base->max_size && may_serve_self) {
+		has_reservation = false;
 		pool->active_count++;
 		if (pool_create_resource(pool, result)) {
 			return true;
@@ -908,13 +990,21 @@ retry:
 	}
 
 	/* 4. Wait - like channel */
-	pool_wait_for_resource(pool, timeout_ms);
+	has_reservation = pool_wait_for_resource(pool, timeout_ms);
 
 	if (UNEXPECTED(EG(exception))) {
 		return false;
 	}
 
 	goto retry;
+
+give_up:
+	/* Leaving without spending the reservation: hand it back to the queue. */
+	if (has_reservation) {
+		pool_wake_waiter(pool);
+	}
+
+	return false;
 }
 
 bool zend_async_pool_try_acquire(async_pool_t *pool, zval *result)
@@ -931,8 +1021,11 @@ retry:
 		return false;
 	}
 
+	/* Same rule as the blocking path: never take a reserved place. */
+	const bool may_serve_self = ASYNC_POOL_UNRESERVED(pool) > 0;
+
 	/* Have idle? */
-	if (!circular_buffer_is_empty(&pool->idle)) {
+	if (!circular_buffer_is_empty(&pool->idle) && may_serve_self) {
 		zval resource;
 		zval_circular_buffer_pop(&pool->idle, &resource);
 
@@ -956,12 +1049,16 @@ retry:
 
 	/* Can create new? Reserve slot before factory (may yield). */
 	const uint32_t total = ASYNC_POOL_TOTAL(pool);
-	if (total < base->max_size) {
+	if (total < base->max_size && may_serve_self) {
 		pool->active_count++;
 		if (pool_create_resource(pool, result)) {
 			return true;
 		}
 		pool->active_count--;
+
+		/* Nothing else reports the freed capacity to the queue — same reason as
+		 * in zend_async_pool_acquire. */
+		pool_wake_waiter(pool);
 	}
 
 	/* No resource available */
@@ -980,7 +1077,7 @@ void zend_async_pool_release(async_pool_t *pool, zval *resource)
 	if (!reusable) {
 		/* Report failure to strategy */
 		pool_strategy_report_failure(pool, NULL);
-		pool_destroy_resource(pool, resource);
+		pool_destroy_borrowed_resource(pool, resource);
 		/* Slot is now free (total dropped) but no idle resource was returned.
 		 * Wake one waiter so it can try to create a fresh resource instead of
 		 * parking forever — without this the pool deadlocks when every
@@ -994,19 +1091,14 @@ void zend_async_pool_release(async_pool_t *pool, zval *resource)
 
 	/* Closed? Destroy resource */
 	if (ZEND_ASYNC_POOL_IS_CLOSED(pool)) {
-		pool_destroy_resource(pool, resource);
+		pool_destroy_borrowed_resource(pool, resource);
 		return;
 	}
 
-	/* Have waiters? Wake first one - it will take resource in retry */
-	if (pool_wake_waiter(pool)) {
-		/* Return resource to buffer, waiter will take it */
-		zval_circular_buffer_push(&pool->idle, resource, true);
-		return;
-	}
-
-	/* No waiters - just return to buffer */
+	/* Buffer first: the woken waiter must find the resource in place, and until
+	 * it runs the reservation keeps everyone else off. */
 	zval_circular_buffer_push(&pool->idle, resource, true);
+	pool_wake_waiter(pool);
 }
 
 void zend_async_pool_close(async_pool_t *pool)

--- a/pool.h
+++ b/pool.h
@@ -30,6 +30,9 @@
 typedef struct
 {
 	zend_coroutine_event_callback_t callback;
+	/* An idle resource or free capacity is reserved for this waiter. A waiter
+	 * that leaves without taking its place wakes the next one. */
+	bool reserved;
 } zend_async_pool_waiter_t;
 
 /**
@@ -44,6 +47,9 @@ typedef struct _async_pool_s
 	/* Storage */
 	circular_buffer_t idle; /* idle resources (zval) */
 	uint32_t active_count;  /* resources currently in use */
+	/* Waiters holding a reservation that have not run yet. No other coroutine
+	 * may take their places until they do. */
+	uint32_t reserved_count;
 
 	/* Waiters queue - like waiting_receivers in channel */
 	zend_async_callbacks_vector_t waiters;
@@ -56,6 +62,12 @@ typedef struct _async_pool_s
 
 /* Helper macros */
 #define ASYNC_POOL_TOTAL(pool) (circular_buffer_count(&(pool)->idle) + (pool)->active_count)
+
+/* Places open to a caller right now — an idle resource or the capacity to
+ * create one — with the reserved ones already subtracted. Since idle + active
+ * never exceeds max_size, the places are max_size minus what is held. */
+#define ASYNC_POOL_UNRESERVED(pool) \
+	((pool)->base.max_size - (pool)->active_count - (pool)->reserved_count)
 
 #define ZEND_ASYNC_POOL_IS_CLOSED(pool) ZEND_ASYNC_EVENT_IS_CLOSED(&(pool)->base.event)
 

--- a/tests/pool/058-pool_release_does_not_barge.phpt
+++ b/tests/pool/058-pool_release_does_not_barge.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Pool: releasing coroutine does not take its own slot back ahead of a parked waiter
+--FILE--
+<?php
+
+use Async\Pool;
+use function Async\spawn;
+use function Async\await;
+use function Async\suspend;
+
+$pool = new Pool(
+    factory: function() {
+        static $c = 0;
+        return "r" . ++$c;
+    },
+    max: 1
+);
+
+$log = [];
+
+// Per-iteration acquire/release with no suspension point between release and
+// the next acquire - the pattern the PDO pool binding produces.
+$worker = function(string $name) use ($pool, &$log) {
+    for ($i = 0; $i < 3; $i++) {
+        $r = $pool->acquire();
+        $log[] = $name . $i;
+        suspend();
+        $pool->release($r);
+    }
+};
+
+$a = spawn($worker, 'A');
+$b = spawn($worker, 'B');
+
+await($a);
+await($b);
+
+echo implode(' ', $log), "\n";
+echo "Created: " . $pool->count() . "\n";
+echo "Done\n";
+?>
+--EXPECT--
+A0 B0 A1 B1 A2 B2
+Created: 1
+Done

--- a/tests/pool/059-pool_waiters_served_in_order.phpt
+++ b/tests/pool/059-pool_waiters_served_in_order.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Pool: waiters are served in arrival order
+--FILE--
+<?php
+
+use Async\Pool;
+use function Async\spawn;
+use function Async\await;
+use function Async\suspend;
+
+$pool = new Pool(factory: fn() => 'r', max: 1);
+
+$order = [];
+
+$workers = [];
+for ($i = 0; $i < 6; $i++) {
+    $workers[] = spawn(function() use ($pool, $i, &$order) {
+        for ($k = 0; $k < 3; $k++) {
+            $r = $pool->acquire();
+            $order[] = $i;
+            suspend();
+            $pool->release($r);
+            suspend();
+        }
+    });
+}
+
+foreach ($workers as $w) {
+    await($w);
+}
+
+echo implode(' ', $order), "\n";
+echo "Done\n";
+?>
+--EXPECT--
+0 1 2 3 4 5 0 1 2 3 4 5 0 1 2 3 4 5
+Done

--- a/tests/pool/060-pool_cancelled_waiter_hands_wakeup_on.phpt
+++ b/tests/pool/060-pool_cancelled_waiter_hands_wakeup_on.phpt
@@ -1,0 +1,57 @@
+--TEST--
+Pool: a cancelled waiter hands its reservation to the next one
+--FILE--
+<?php
+
+use Async\Pool;
+use function Async\spawn;
+use function Async\await;
+use function Async\suspend;
+
+$pool = new Pool(factory: fn() => 'r', max: 1);
+
+$holder = spawn(function() use ($pool) {
+    $r = $pool->acquire();
+    suspend();
+    suspend();
+    $pool->release($r);
+});
+
+$w1 = spawn(function() use ($pool) {
+    try {
+        $r = $pool->acquire();
+        echo "W1 acquired\n";
+        $pool->release($r);
+    } catch (Throwable $e) {
+        echo "W1: " . get_class($e) . "\n";
+    }
+});
+
+$w2 = spawn(function() use ($pool) {
+    $r = $pool->acquire();
+    echo "W2 acquired\n";
+    $pool->release($r);
+});
+
+suspend();      // holder acquires, W1 and W2 park in that order
+suspend();
+suspend();      // holder releases: the resource is reserved for W1
+
+$w1->cancel();  // W1 is cancelled before it can take the reserved resource
+
+try {
+    await($w1);
+} catch (Throwable $e) {
+}
+
+await($w2);
+await($holder);
+
+echo "Idle: " . $pool->idleCount() . "\n";
+echo "Done\n";
+?>
+--EXPECT--
+W1: Async\AsyncCancellation
+W2 acquired
+Idle: 1
+Done

--- a/tests/pool/061-pool_tryAcquire_respects_reservation.phpt
+++ b/tests/pool/061-pool_tryAcquire_respects_reservation.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Pool: tryAcquire does not take a resource reserved for a parked waiter
+--FILE--
+<?php
+
+use Async\Pool;
+use function Async\spawn;
+use function Async\await;
+use function Async\suspend;
+
+$pool = new Pool(factory: fn() => 'r', max: 1);
+
+$holder = spawn(function() use ($pool) {
+    $r = $pool->acquire();
+    suspend();
+    suspend();
+    $pool->release($r);
+});
+
+$waiter = spawn(function() use ($pool) {
+    $r = $pool->acquire();
+    echo "Waiter acquired\n";
+    $pool->release($r);
+});
+
+suspend();      // holder acquires, waiter parks
+suspend();
+suspend();      // holder releases: the resource is reserved for the waiter
+
+var_dump($pool->tryAcquire());
+
+await($waiter);
+await($holder);
+
+echo "Idle: " . $pool->idleCount() . "\n";
+echo "Done\n";
+?>
+--EXPECT--
+NULL
+Waiter acquired
+Idle: 1
+Done

--- a/tests/pool/062-pool_cancelled_waiter_keeps_resource.phpt
+++ b/tests/pool/062-pool_cancelled_waiter_keeps_resource.phpt
@@ -1,0 +1,68 @@
+--TEST--
+Pool: a cancelled waiter with no successor leaves its resource reusable
+--FILE--
+<?php
+
+use Async\Pool;
+use function Async\spawn;
+use function Async\await;
+use function Async\suspend;
+
+$created = 0;
+
+$pool = new Pool(
+    factory: function() use (&$created) {
+        $created++;
+        return "r" . $created;
+    },
+    max: 1
+);
+
+$holder = spawn(function() use ($pool) {
+    $r = $pool->acquire();
+    suspend();
+    suspend();
+    $pool->release($r);
+});
+
+$waiter = spawn(function() use ($pool) {
+    try {
+        $r = $pool->acquire();
+        echo "Waiter acquired\n";
+        $pool->release($r);
+    } catch (Throwable $e) {
+        echo "Waiter: " . get_class($e) . "\n";
+    }
+});
+
+suspend();          // holder acquires, waiter parks
+suspend();
+suspend();          // holder releases: the resource is reserved for the waiter
+
+$waiter->cancel();  // nobody is left to hand the reservation to
+
+try {
+    await($waiter);
+} catch (Throwable $e) {
+}
+
+await($holder);
+
+echo "Factory calls: $created\n";
+echo "Idle: " . $pool->idleCount() . "\n";
+
+$late = spawn(function() use ($pool) {
+    echo "Late acquired: " . $pool->acquire() . "\n";
+});
+await($late);
+
+echo "Factory calls: $created\n";
+echo "Done\n";
+?>
+--EXPECT--
+Waiter: Async\AsyncCancellation
+Factory calls: 1
+Idle: 1
+Late acquired: r1
+Factory calls: 1
+Done

--- a/tests/pool/063-pool_close_with_reserved_resource.phpt
+++ b/tests/pool/063-pool_close_with_reserved_resource.phpt
@@ -1,0 +1,61 @@
+--TEST--
+Pool: closing while a resource is reserved for a waiter destroys it exactly once
+--FILE--
+<?php
+
+use Async\Pool;
+use function Async\spawn;
+use function Async\await;
+use function Async\suspend;
+
+$created = 0;
+$destroyed = 0;
+
+$pool = new Pool(
+    factory: function() use (&$created) {
+        $created++;
+        return "r" . $created;
+    },
+    destructor: function($resource) use (&$destroyed) {
+        $destroyed++;
+    },
+    max: 1
+);
+
+$holder = spawn(function() use ($pool) {
+    $r = $pool->acquire();
+    suspend();
+    suspend();
+    $pool->release($r);
+});
+
+$waiter = spawn(function() use ($pool) {
+    try {
+        $r = $pool->acquire();
+        echo "Waiter acquired\n";
+        $pool->release($r);
+    } catch (Throwable $e) {
+        echo "Waiter: " . get_class($e) . "\n";
+    }
+});
+
+suspend();      // holder acquires, waiter parks
+suspend();
+suspend();      // holder releases: the resource is reserved for the waiter
+
+$pool->close();
+
+await($waiter);
+await($holder);
+
+echo "Factory calls: $created\n";
+echo "Destructor calls: $destroyed\n";
+echo "Idle: " . $pool->idleCount() . "\n";
+echo "Done\n";
+?>
+--EXPECT--
+Waiter: Async\PoolException
+Factory calls: 1
+Destructor calls: 1
+Idle: 0
+Done

--- a/tests/pool/064-pool_capacity_wakeup_handed_on.phpt
+++ b/tests/pool/064-pool_capacity_wakeup_handed_on.phpt
@@ -1,0 +1,61 @@
+--TEST--
+Pool: a cancelled waiter hands on a reservation that was capacity, not a resource
+--FILE--
+<?php
+
+use Async\Pool;
+use function Async\spawn;
+use function Async\await;
+use function Async\suspend;
+
+// beforeRelease rejects every resource, so a release frees capacity and leaves
+// the idle buffer empty: the reservation is the right to create, nothing else.
+$pool = new Pool(
+    factory: fn() => 'r',
+    beforeRelease: fn($r) => false,
+    max: 1
+);
+
+$holder = spawn(function() use ($pool) {
+    $r = $pool->acquire();
+    suspend();
+    suspend();
+    $pool->release($r);
+});
+
+$w1 = spawn(function() use ($pool) {
+    try {
+        $pool->acquire();
+        echo "W1 acquired\n";
+    } catch (Throwable $e) {
+        echo "W1: " . get_class($e) . "\n";
+    }
+});
+
+$w2 = spawn(function() use ($pool) {
+    $pool->acquire();
+    echo "W2 acquired\n";
+});
+
+suspend();      // holder acquires, W1 and W2 park
+suspend();
+suspend();      // holder releases a rejected resource: capacity is reserved for W1
+
+$w1->cancel();
+
+try {
+    await($w1);
+} catch (Throwable $e) {
+}
+
+await($w2);
+await($holder);
+
+echo "Idle: " . $pool->idleCount() . "\n";
+echo "Done\n";
+?>
+--EXPECT--
+W1: Async\AsyncCancellation
+W2 acquired
+Idle: 0
+Done

--- a/tests/pool/065-pool_surplus_stays_available.phpt
+++ b/tests/pool/065-pool_surplus_stays_available.phpt
@@ -1,0 +1,65 @@
+--TEST--
+Pool: resources beyond the ones reserved for waiters stay available
+--FILE--
+<?php
+
+use Async\Pool;
+use function Async\spawn;
+use function Async\await;
+use function Async\await_all;
+use function Async\suspend;
+
+$created = 0;
+
+$pool = new Pool(
+    factory: function() use (&$created) {
+        $created++;
+        return "r" . $created;
+    },
+    max: 3
+);
+
+$holders = [];
+for ($i = 0; $i < 3; $i++) {
+    $holders[] = spawn(function() use ($pool) {
+        $r = $pool->acquire();
+        suspend();
+        suspend();
+        $pool->release($r);
+    });
+}
+
+suspend();
+
+// One waiter: after the three releases one resource is reserved for it, the
+// other two are unreserved and must stay acquirable.
+$waiter = spawn(function() use ($pool) {
+    $r = $pool->acquire();
+    echo "Waiter acquired\n";
+    suspend();
+    suspend();
+    suspend();
+    $pool->release($r);
+});
+
+suspend();      // waiter parks
+suspend();      // three releases in one tick, one reservation made
+
+echo "Idle: " . $pool->idleCount() . "\n";
+
+$surplus = $pool->tryAcquire();
+var_dump($surplus !== null);
+$pool->release($surplus);
+
+await($waiter);
+await_all($holders);
+
+echo "Created: $created\n";
+echo "Done\n";
+?>
+--EXPECT--
+Idle: 3
+bool(true)
+Waiter acquired
+Created: 3
+Done

--- a/tests/pool/066-pool_deactivate_hands_reservation_on.phpt
+++ b/tests/pool/066-pool_deactivate_hands_reservation_on.phpt
@@ -1,0 +1,55 @@
+--TEST--
+Pool: a waiter leaving through the circuit breaker hands its reservation on
+--FILE--
+<?php
+
+use Async\Pool;
+use function Async\spawn;
+use function Async\await;
+use function Async\suspend;
+
+$pool = new Pool(factory: fn() => 'r', max: 1);
+
+$holder = spawn(function() use ($pool) {
+    $r = $pool->acquire();
+    suspend();
+    suspend();
+    $pool->release($r);
+});
+
+$w1 = spawn(function() use ($pool) {
+    try {
+        $pool->acquire();
+        echo "W1 acquired\n";
+    } catch (Throwable $e) {
+        echo "W1: " . get_class($e) . "\n";
+    }
+});
+
+$w2 = spawn(function() use ($pool) {
+    try {
+        $pool->acquire();
+        echo "W2 acquired\n";
+    } catch (Throwable $e) {
+        echo "W2: " . get_class($e) . "\n";
+    }
+});
+
+suspend();      // holder acquires, W1 and W2 park
+suspend();
+suspend();      // holder releases: the resource is reserved for W1
+
+// W1 has not run yet: it finds the pool unavailable and leaves without
+// spending its reservation.
+$pool->deactivate();
+
+await($w1);
+await($w2);
+await($holder);
+
+echo "Done\n";
+?>
+--EXPECT--
+W1: Async\ServiceUnavailableException
+W2: Async\ServiceUnavailableException
+Done

--- a/tests/pool/067-pool_release_keeps_callers_reference.phpt
+++ b/tests/pool/067-pool_release_keeps_callers_reference.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Pool: release() does not free the caller's own reference to the resource
+--FILE--
+<?php
+
+use Async\Pool;
+use function Async\spawn;
+use function Async\await;
+
+$destroyed = 0;
+
+$pool = new Pool(
+    factory: fn() => new stdClass(),
+    destructor: function($resource) use (&$destroyed) { $destroyed++; },
+    beforeRelease: fn($r) => false,   // every release destroys the resource
+    max: 1
+);
+
+$c = spawn(function() use ($pool, &$destroyed) {
+    $r = $pool->acquire();
+    $r->tag = 'mine';
+
+    $pool->release($r);
+    echo "Destroyed: $destroyed\n";
+
+    // The pool destroyed its resource; the caller's variable is still valid.
+    echo "Tag: " . $r->tag . "\n";
+});
+
+await($c);
+
+echo "Idle: " . $pool->idleCount() . "\n";
+echo "Done\n";
+?>
+--EXPECT--
+Destroyed: 1
+Tag: mine
+Idle: 0
+Done


### PR DESCRIPTION
Fixes #235.

## The defect

`zend_async_pool_release` pushed the resource into the shared `idle` buffer and woke one waiter, but a wake only enqueues the coroutine (`async_coroutine_resume`). The releasing coroutine kept running and, in a loop like `acquire → I/O → release → acquire`, took its own slot back before the woken waiter ever ran. Parked coroutines were served only when a holder left its loop for good — the 10-60 s latency outliers reported under `PDO::ATTR_POOL_ENABLED` with per-query release.

Three more defects on the same path:

* a woken waiter that was cancelled or timed out took the wakeup with it, and the rest of the queue parked with no wakeup coming (`Async\DeadlockError` on a live pool);
* the waiter queue was not FIFO — removal moved the last element into the freed head, so the newest waiter was served second and the middle of the queue stalled;
* `release()` dropped a reference it never took when it destroyed a rejected resource, freeing the caller's variable out from under it (`zend_mm_heap corrupted`).

## The fix

A place is either an idle resource or the capacity to create one. The pool counts the places reserved for woken waiters (`reserved_count`); a coroutine holding a reservation spends it, everyone else — the releasing coroutine included — takes only the surplus. `pool_wake_waiter` reserves for the oldest unreserved waiter and leaves it queued, so nothing can be taken out from under a waiter on its way to collect it.

A waiter that leaves without spending its reservation hands it on: on cancellation, on timeout, on an open circuit breaker, and whether the reservation was a resource or free capacity. Removal from the queue preserves arrival order; the drain-everything path at close takes from the tail, where order is meaningless.

Also here: `tryAcquire()` follows the same rule instead of jumping the queue, it wakes a waiter when its factory fails, the healthcheck reports the capacity it frees, and the pool's deadlock report prints `reserved` — idle resources with waiters queued read as a lost wakeup until you can see they are reserved.

## Measurements

| | before | after |
|---|---|---|
| 16 coroutines over `max: 5`, first acquire | up to 663 ms, in waves | 3.7 ms |
| 6 coroutines over `max: 1`, service order | `0 1 5 0 1 5 0 1 5 4 3 2 …` | `0 1 2 3 4 5` ×3 |
| cancelled waiter with a resource idle | `DeadlockError` | next waiter served |
| cancelled waiter with capacity freed | `DeadlockError` | next waiter served |
| `tryAcquire()` with 3 idle and 1 waiter | `NULL` | serves the surplus |
| `$pool->release($obj)` with a rejecting `beforeRelease` | `zend_mm_heap corrupted` | caller's variable intact |

## Tests

Ten phpt tests under `tests/pool`. Seven fail on a build without this change: 058 (barging), 059 (arrival order), 060 (cancelled waiter hands its reservation on), 061 (`tryAcquire` respects a reservation), 064 (capacity reservation handed on), 066 (circuit breaker hands the reservation on), 067 (`release()` keeps the caller's reference). The other three — 062, 063, 065 — guard the new machinery and pass on both.

* `ext/async/tests/pool`: 67/67, and under valgrind with no leaks
* full `ext/async` suite: unchanged, 3 known symlink-path failures only
* `ext/async/tests/pdo_sqlite` 21/21, `pdo_mysql` 28/28 against a live server, `mysqli` 10/10
* `ext/pdo/tests/pdo_pool_*` 28/28, `ext/pdo_sqlite/tests/pool_*` 15/15
