### PR TITLE
tests(pdo_mysql): pin the cancellation that lands mid-connect

### DIFF
--- a/tests/pdo_mysql/029-cancel_during_connect.phpt
+++ b/tests/pdo_mysql/029-cancel_during_connect.phpt
@@ -1,0 +1,65 @@
+--TEST--
+PDO MySQL: a cancellation landing mid-connect surfaces as AsyncCancellation
+--EXTENSIONS--
+pdo_mysql
+--SKIPIF--
+<?php
+require_once __DIR__ . '/inc/async_pdo_mysql_test.inc';
+AsyncPDOMySQLTest::skipIfNoAsync();
+AsyncPDOMySQLTest::skipIfNoPDOMySQL();
+AsyncPDOMySQLTest::skip();
+?>
+--FILE--
+<?php
+require_once __DIR__ . '/inc/async_pdo_mysql_test.inc';
+
+use function Async\spawn;
+use function Async\await;
+
+// Cancel at a spread of delays so that some attempts land while the driver is
+// still connecting. There the socket is torn down under it and the driver
+// reports a connection error of its own - the caller must still see the
+// cancellation, or catch (AsyncCancellation) stops working.
+$outcomes = [];
+
+for ($delay = 0; $delay <= 4000; $delay += 200) {
+    $coroutine = spawn(function() {
+        try {
+            AsyncPDOMySQLTest::factory();
+            return "connected";
+        } catch (Async\AsyncCancellation $e) {
+            return "cancelled";
+        } catch (Throwable $e) {
+            return "leaked " . get_class($e);
+        }
+    });
+
+    if ($delay > 0) {
+        usleep($delay);
+    }
+
+    $coroutine->cancel();
+
+    try {
+        $outcomes[await($coroutine)] = true;
+    } catch (Async\AsyncCancellation $e) {
+        $outcomes["cancelled before start"] = true;
+    } catch (Throwable $e) {
+        $outcomes["leaked " . get_class($e)] = true;
+    }
+}
+
+$seen = array_keys($outcomes);
+sort($seen);
+
+foreach ($seen as $outcome) {
+    echo $outcome, "\n";
+}
+
+echo "end\n";
+?>
+--EXPECT--
+cancelled
+cancelled before start
+connected
+end


### PR DESCRIPTION
Regression test for true-async/php-src#22, merged into `true-async` and `true-async-stable`.

## What it covers

Cancelling a coroutine while the driver is still connecting tore the socket down under it; mysqlnd reported a connection failure of its own, PDO threw it as `PDOException`, and the pending `AsyncCancellation` was attached to it as `previous`. `catch (Async\AsyncCancellation)` therefore missed it and the coroutine died with an uncaught `PDOException`.

That is what made `009-pdo_cancellation.phpt` fail in CI, where connecting is slow enough for the cancellation to land inside `PDO::__construct`: https://github.com/true-async/php-async/actions/runs/32065048014/job/95495005584

## The test

`tests/pdo_mysql/029-cancel_during_connect.phpt` cancels at a spread of delays from 0 to 4000 µs, so some attempts land inside the connect and others before or after it, and requires the set of outcomes to be exactly `cancelled`, `cancelled before start` and `connected`. Against a php-src without the fix it fails three runs out of three, with `leaked PDOException` in the diff.

Verified with the merged php-src: `ext/async/tests/pdo_mysql` 29/29 against a live server.