### PR TITLE
#234: stop asserting how many GC runs the collection took

### DIFF
--- a/tests/gc/015-gc_threshold_stable_in_async.phpt
+++ b/tests/gc/015-gc_threshold_stable_in_async.phpt
@@ -19,6 +19,8 @@ function make_cycles(int $count): void
         unset($a, $b);
 
         // Give the GC coroutine a chance to run between full root buffers.
+        // The last iteration lands on this branch too, which is what leaves
+        // nothing uncollected by the time gc_status() below is read.
         if ($i % 10000 === 0) {
             delay(1);
         }
@@ -33,19 +35,18 @@ await(spawn(fn() => make_cycles(40000)));
 $status = gc_status();
 
 // What was collected is asserted too: a threshold that never moves also
-// describes an engine whose deferred collection never happens at all. How many
-// runs that took is not asserted — it says how often the GC coroutine got
-// scheduled, not what this test is about. Measured on this very body: a delay
-// every 10000 cycles gives four runs, one every 40000 gives one, and no delay
-// at all gives one, while the collected count is 80000 in each case.
+// describes an engine whose deferred collection never happens at all, and a
+// collected count proves the collection ran. How many runs it took is not
+// asserted — that says how often the GC coroutine got scheduled, which the
+// code under test does not decide. Measured on this very body: a delay every
+// 10000 cycles gives four runs, one every 40000 gives one, and no delay at all
+// gives one, while the collected count is 80000 in each case.
 echo "threshold before: $before\n";
 echo "threshold after: ", $status['threshold'], "\n";
-echo "collected anything: ", $status['runs'] > 0 ? 'yes' : 'no', "\n";
 echo "collected: ", $status['collected'], "\n";
 
 ?>
 --EXPECT--
 threshold before: 10001
 threshold after: 10001
-collected anything: yes
 collected: 80000

--- a/tests/gc/015-gc_threshold_stable_in_async.phpt
+++ b/tests/gc/015-gc_threshold_stable_in_async.phpt
@@ -32,16 +32,20 @@ await(spawn(fn() => make_cycles(40000)));
 
 $status = gc_status();
 
-// The counts are asserted too: a threshold that never moves also describes an
-// engine whose deferred collection never happens at all.
+// What was collected is asserted too: a threshold that never moves also
+// describes an engine whose deferred collection never happens at all. How many
+// runs that took is not asserted — it says how often the GC coroutine got
+// scheduled, not what this test is about. Measured on this very body: a delay
+// every 10000 cycles gives four runs, one every 40000 gives one, and no delay
+// at all gives one, while the collected count is 80000 in each case.
 echo "threshold before: $before\n";
 echo "threshold after: ", $status['threshold'], "\n";
-echo "runs: ", $status['runs'], "\n";
+echo "collected anything: ", $status['runs'] > 0 ? 'yes' : 'no', "\n";
 echo "collected: ", $status['collected'], "\n";
 
 ?>
 --EXPECT--
 threshold before: 10001
 threshold after: 10001
-runs: 4
+collected anything: yes
 collected: 80000


### PR DESCRIPTION
## What was wrong

`tests/gc/015-gc_threshold_stable_in_async.phpt` asserted `runs: 4`. That counter says how often the GC coroutine got scheduled during the run, which the code under test does not decide. On `LINUX_X64_DEBUG_ZTS_ASAN` two full root buffers merge into a single deferred collection and the test reports 3, with the same 80000 objects collected:

```
     threshold before: 10001
     threshold after: 10001
003- runs: 4
003+ runs: 3
     collected: 80000
```

Measured on the same body, without ASAN, by moving only the point where the GC coroutine gets a chance to run:

```
delay(1) every 10000 cycles  ->  runs: 4   collected: 80000
delay(1) every 40000         ->  runs: 1   collected: 80000
no delay at all              ->  runs: 1   collected: 80000
```

The collected count never moves; the run count moves by a factor of four.

## What changed

The test now says that deferred collection happened at all, which is what that counter was added to guard — the comment in the test says as much. The threshold assertions and the exact collected count are untouched, so what the test proves about #234 is unchanged.

## Verification

12 runs of the test and the whole `tests/gc` group, 23 tests, 0 failed. Not reproduced without ASAN: 12 clean runs and 15 under 24 spinning load generators all gave 4.