### PR TITLE
#231: stop asserting a live worker count right after cancel

### DIFF
--- a/tests/thread_pool/021-cancel_on_empty_pool.phpt
+++ b/tests/thread_pool/021-cancel_on_empty_pool.phpt
@@ -15,11 +15,12 @@ spawn(function() {
     $pool = new ThreadPool(4);
     $pool->cancel();
     echo "closed=" . ($pool->isClosed() ? "yes" : "no") . "\n";
-    echo "workers=" . $pool->getWorkerCount() . "\n";
+    // The live worker count is not asserted here: cancel() has told the
+    // threads to leave and does not wait for them, so the number depends on
+    // how far they got. 082-worker_liveness.phpt covers what the count means.
     echo "done\n";
 });
 ?>
 --EXPECT--
 closed=yes
-workers=4
 done


### PR DESCRIPTION
Follow-up to #244.

`tests/thread_pool/021-cancel_on_empty_pool.phpt` asserts `workers=4` after `new ThreadPool(4)` followed by `cancel()`. Before #244 that number was the constructed size — a constant, so the assertion always held. Since #244 `getWorkerCount()` reports the workers that are running, and `cancel()` tells the threads to leave without waiting for them, so the value depends on how far they got: the run on #246 read 3 and failed, while #244's own run read 4 and passed.

The count line is removed rather than loosened. What the test is about is that cancelling a pool that never received a task closes it and returns; what the count means is covered by `082-worker_liveness.phpt`, added in #244.

Ran 3 times locally: pass.