### PR TITLE
#256: drop the stale --XFAIL-- from 030-submit_closure_class_return_type

### DIFF
--- a/tests/thread_pool/030-submit_closure_class_return_type.phpt
+++ b/tests/thread_pool/030-submit_closure_class_return_type.phpt
@@ -1,15 +1,5 @@
 --TEST--
 ThreadPool: closure with class-name return type (regression: arg_info[-1].type not deep-copied)
---XFAIL--
-Returning a Closure from a worker thread is not yet implemented.
-The worker creates a per-result closure snapshot in closure_transfer_obj
-(TRANSFER branch), but the result-closure's persistent shell ends up
-referencing memory in the task snapshot arena, which the worker frees
-in thread_pool_worker_handler before the main thread loads the result.
-This causes a heap-use-after-free in async_thread_create_closure when
-iterating bound_vars on the loading side. Proper support requires the
-result-closure snapshot to own its own arena and outlive the task
-snapshot until the loading thread consumes it.
 --SKIPIF--
 <?php
 if (!PHP_ZTS) die('skip ZTS required');


### PR DESCRIPTION
Closes #256.

The `--XFAIL--` on `030-submit_closure_class_return_type` predicted a use-after-free in `async_thread_create_closure` when a Closure is returned from a worker. It does not happen: the test passes 20 runs of 20, and three runs under valgrind report no invalid read.

While the section stood, every suite run printed a warning, and a real regression in that path would have been recorded as an expected failure and gone unnoticed.

Removing it is the whole change. `tests`: 1192 passed, 0 failed, **0 warned**.

Build: ZTS DEBUG, TrueAsync ABI v0.24.0.
