### PR TITLE
Honour ZEND_ASYNC_IO_WRITEV_AWAIT: a vectored write the caller can wait for

### DIFF
--- a/libuv_reactor.c
+++ b/libuv_reactor.c
@@ -6057,7 +6057,31 @@ static zend_async_io_req_t *libuv_io_writev(zend_async_io_t *io_base,
 	const bool iov_mode = (flags & ZEND_ASYNC_IO_WRITEV_MODE_MASK) == ZEND_ASYNC_IO_WRITEV_IOV;
 	const bool awaited  = (flags & ZEND_ASYNC_IO_WRITEV_AWAIT) != 0;
 
-	ZEND_ASSERT((flags & ~(ZEND_ASYNC_IO_WRITEV_MODE_MASK | ZEND_ASYNC_IO_WRITEV_AWAIT)) == 0);
+	/* Refuse rather than assert: a caller from a newer header would otherwise
+	 * abort on a debug build and, on a release one, get whatever the unknown
+	 * bit happens to mean here — the quiet outcome being the dangerous one.
+	 * AWAIT is ZSTR-only, because the awaited completion hands the request to
+	 * its awaiter and so cannot also promise the IOV contract that free_cb
+	 * runs at completion. The release below is the CLOSED branch's. */
+	if (UNEXPECTED((flags & ~(ZEND_ASYNC_IO_WRITEV_MODE_MASK | ZEND_ASYNC_IO_WRITEV_AWAIT)) != 0)
+	    || UNEXPECTED(iov_mode && awaited)) {
+		if (nbufs > 0) {
+			if (iov_mode) {
+				if (free_cb != NULL) {
+					free_cb(user_data, io_base);
+				}
+			} else {
+				zend_string **zbufs = (zend_string **) bufs;
+
+				for (unsigned i = 0; i < nbufs; i++) {
+					zend_string_release(zbufs[i]);
+				}
+			}
+		}
+
+		async_throw_error("Unsupported writev flags 0x%x", flags);
+		return NULL;
+	}
 
 	if (UNEXPECTED(nbufs == 0)) {
 		if (iov_mode && free_cb != NULL) {

--- a/libuv_reactor.c
+++ b/libuv_reactor.c
@@ -4939,9 +4939,10 @@ static void io_pipe_write_cb(uv_write_t *write_request, int status)
 	IF_EXCEPTION_STOP_REACTOR;
 }
 
-/* Vectored fire-and-forget completion. Releases every owned zend_string ref
- * stored in the trailing slot array, then frees the request. No NOTIFY:
- * writev is fire-and-forget by design (no caller awaits this req). On
+/* Vectored write completion. Releases every owned zend_string ref stored in the
+ * trailing slot array, then either hands the request to its awaiter or frees it.
+ *
+ * Without ZEND_ASYNC_IO_WRITEV_AWAIT there is no awaiter and no NOTIFY: on a
  * write error the connection layer surfaces the failure on its next read
  * attempt and tears the conn down, just like ZEND_ASYNC_IO_WRITE_EX. */
 static void io_pipe_writev_cb(uv_write_t *write_request, int status)
@@ -4968,7 +4969,28 @@ static void io_pipe_writev_cb(uv_write_t *write_request, int status)
 			zend_string_release(slots[i]);
 		}
 		req->writev_nbufs = 0;
-	} else if (req->base.free_cb != NULL) {
+	}
+
+	/* Awaited: the request belongs to its awaiter, which reads the status off
+	 * it and disposes it, so neither the exception nor the request is freed
+	 * here. An awaiter that left while the write was queued has already asked
+	 * for the dispose; finish it now that the buffers are released. */
+	if (req->uv_flags & ASYNC_IO_REQ_F_AWAITED) {
+		if (UNEXPECTED(req->uv_flags & ASYNC_IO_REQ_F_DISPOSE_PENDING)) {
+			libuv_io_req_dispose(&req->base);
+		} else {
+			/* No exception on the broadcast. Every listener on this event
+			 * forwards an exception unconditionally and filters by result
+			 * otherwise, so passing one here would wake every reader and
+			 * writer on the handle instead of the one that asked. */
+			ZEND_ASYNC_CALLBACKS_NOTIFY(&req->io->base.event, &req->base, NULL);
+		}
+
+		IF_EXCEPTION_STOP_REACTOR;
+		return;
+	}
+
+	if (req->base.free_cb != NULL) {
 		/* IOV mode: one free_cb for the whole batch. */
 		zend_async_io_write_free_cb_t free_cb = req->base.free_cb;
 		void *user_data = req->base.buf;
@@ -6034,7 +6056,10 @@ static zend_async_io_req_t *libuv_io_writev(zend_async_io_t *io_base,
                                             void *user_data)
 {
 	async_io_t *io = (async_io_t *) io_base;
-	const bool iov_mode = (flags == ZEND_ASYNC_IO_WRITEV_IOV);
+	const bool iov_mode = (flags & ZEND_ASYNC_IO_WRITEV_MODE_MASK) == ZEND_ASYNC_IO_WRITEV_IOV;
+	const bool awaited  = (flags & ZEND_ASYNC_IO_WRITEV_AWAIT) != 0;
+
+	ZEND_ASSERT((flags & ~(ZEND_ASYNC_IO_WRITEV_MODE_MASK | ZEND_ASYNC_IO_WRITEV_AWAIT)) == 0);
 
 	if (UNEXPECTED(nbufs == 0)) {
 		if (iov_mode && free_cb != NULL) {
@@ -6081,6 +6106,10 @@ static zend_async_io_req_t *libuv_io_writev(zend_async_io_t *io_base,
 	} else {
 		slots = (zend_string **)((char *) req + sizeof(*req));
 		req->writev_nbufs = (uint16_t) nbufs;
+	}
+
+	if (awaited) {
+		req->uv_flags |= ASYNC_IO_REQ_F_AWAITED;
 	}
 
 	/* uv_buf_t array lives only for the duration of uv_write — libuv copies

--- a/libuv_reactor.c
+++ b/libuv_reactor.c
@@ -4971,18 +4971,16 @@ static void io_pipe_writev_cb(uv_write_t *write_request, int status)
 		req->writev_nbufs = 0;
 	}
 
-	/* Awaited: the request belongs to its awaiter, which reads the status off
-	 * it and disposes it, so neither the exception nor the request is freed
-	 * here. An awaiter that left while the write was queued has already asked
-	 * for the dispose; finish it now that the buffers are released. */
+	/* Awaited: the request belongs to its awaiter, which reads the status and
+	 * disposes it — so neither it nor its exception is freed here. An awaiter
+	 * that left already asked for the dispose; finish it now. */
 	if (req->uv_flags & ASYNC_IO_REQ_F_AWAITED) {
 		if (UNEXPECTED(req->uv_flags & ASYNC_IO_REQ_F_DISPOSE_PENDING)) {
 			libuv_io_req_dispose(&req->base);
 		} else {
-			/* No exception on the broadcast. Every listener on this event
-			 * forwards an exception unconditionally and filters by result
-			 * otherwise, so passing one here would wake every reader and
-			 * writer on the handle instead of the one that asked. */
+			/* No exception on the broadcast: every listener forwards one
+			 * unconditionally and filters by result only otherwise, so it
+			 * would wake the whole handle instead of the one that asked. */
 			ZEND_ASYNC_CALLBACKS_NOTIFY(&req->io->base.event, &req->base, NULL);
 		}
 

--- a/libuv_reactor.h
+++ b/libuv_reactor.h
@@ -208,6 +208,7 @@ struct _async_io_t
  * the completion callback. */
 #define ASYNC_IO_REQ_F_UV_IN_FLIGHT    (1u << 0) /* uv op submitted, callback pending */
 #define ASYNC_IO_REQ_F_DISPOSE_PENDING (1u << 1) /* dispose() arrived while in flight */
+#define ASYNC_IO_REQ_F_AWAITED         (1u << 2) /* writev: notify on completion, caller disposes */
 
 struct _async_io_req_t
 {


### PR DESCRIPTION
Reactor half of true-async/php-src#24. Consumer: true-async/server (HTTP/1 chunk frames).

## Why

The vectored write reports nothing — `io_pipe_writev_cb` freed the request and sent no NOTIFY — so a caller that needs the outcome has to use the single-buffer write. That one does not take the buffer over, so the caller frees it, and the only moment it can is when its own wait ends. Cancel the waiting coroutine and those two moments come apart: the wait is over, the write is still queued, and libuv holds a pointer into memory the caller has released.

Reproduced in the server: a handler parked writing to a peer that never reads, `setShutdownTimeout(0)`, then `stop()`. Probes fired in order — the await returns with `req->completed == false`, `libuv_io_req_dispose` defers because `ASYNC_IO_REQ_F_UV_IN_FLIGHT` is set, and the caller frees a 20008-byte frame. Stamping the freed block showed the allocator hands the same address straight back.

## What changes

`ASYNC_IO_REQ_F_AWAITED` is set at submit when the caller passes the flag. The completion releases the slots exactly as before, then:

- a dispose that arrived while the write was queued is finished here;
- otherwise the request stays alive and `io->event` is notified with the request as the result and **no exception**.

The exception stays on the request. Passing it on the broadcast would wake every reader and writer on the handle, because each listener forwards an exception unconditionally and filters by result only otherwise — that is load-bearing elsewhere (it is how a writer parked on a closed handle is woken), so the awaited path must not use it.

The mode is now read from the low bit instead of by equality, so `ZSTR` and `IOV` keep their values and an unknown bit trips an assert instead of silently selecting a mode.

## Evidence

Built against php-src#24. `ext/async/tests`: 1104 passed, 0 failed. `true-async/server` `tests/phpt` against the same build: 390 passed, 0 failed, with the server's HTTP/1 frame path converted to the new op — after which the caller frees nothing and the probe that caught the early free stops firing.