### PR TITLE
fix(thread): follow upstream's zend_object* for a closure's $this

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -2274,11 +2274,13 @@ void async_thread_request_shutdown(void)
 #endif
 }
 
-/* Closure struct layout — defined in zend_closures.c, not exported */
+/* Closure struct layout — defined in zend_closures.c, not exported. Every field
+ * must match that declaration: a type that differs shifts the fields behind it,
+ * and the compiler says nothing about it. */
 typedef struct {
 	zend_object       std;
 	zend_function     func;
-	zval              this_ptr;
+	zend_object      *this_ptr;
 	zend_class_entry *called_scope;
 	zif_handler       orig_internal_handler;
 } async_zend_closure_t;
@@ -2860,9 +2862,9 @@ void async_thread_create_closure_ex(
 	ZEND_MAP_PTR_INIT(func.op_array.run_time_cache, NULL);
 	func.op_array.fn_flags &= ~ZEND_ACC_HEAP_RT_CACHE;
 
-	zval *this_arg = NULL;
+	zend_object *this_arg = NULL;
 	if (Z_TYPE(loaded_this) == IS_OBJECT) {
-		this_arg = &loaded_this;
+		this_arg = Z_OBJ(loaded_this);
 	}
 
 	/* Kill the source thread's stale CE pointer before handing to the engine. */
@@ -2930,9 +2932,9 @@ static bool thread_call_closure(
 		 * With zend_execute_ex we get the exception cleanly in EG(exception). */
 		uint32_t call_info = ZEND_CALL_TOP_FUNCTION;
 		void *object_or_scope = NULL;
-		if (Z_TYPE(closure->this_ptr) == IS_OBJECT) {
+		if (closure->this_ptr != NULL) {
 			call_info |= ZEND_CALL_HAS_THIS;
-			object_or_scope = Z_OBJ(closure->this_ptr);
+			object_or_scope = closure->this_ptr;
 		} else if (closure->called_scope != NULL) {
 			/* Scoped static call: the frame carries called_scope, no $this. */
 			object_or_scope = closure->called_scope;
@@ -3643,9 +3645,9 @@ static zend_object *closure_transfer_obj(
 		 * $this on first use. */
 		zval closure_zv;
 		ZVAL_OBJ(&closure_zv, object);
-		zval *bound_this = zend_get_closure_this_ptr(&closure_zv);
-		if (bound_this != NULL && Z_TYPE_P(bound_this) == IS_OBJECT) {
-			fcall.fci_cache.object = Z_OBJ_P(bound_this);
+		zend_object *bound_this = zend_get_closure_this_ptr(&closure_zv);
+		if (bound_this != NULL) {
+			fcall.fci_cache.object = bound_this;
 		}
 
 		/* Share our ctx: the captured vars may point back at an object this


### PR DESCRIPTION
Found while merging php-src `master` into `true-async` for the release: 37 of the
`thread` and `thread_channel` tests segfaulted in the worker on the first
property fetch, all of them the `spawn_thread() … $this` shapes.

php-src passes `$this` as a `zend_object*` since php/php-src@fbb2e1f and stores
it as one in `zend_closure` since @7a5e452. Two places here still spoke zval, and
neither is caught at compile time:

- `async_zend_closure_t` (`thread.c:2277`) is a copy of a layout
  `zend_closures.c` does not export. While it said `zval this_ptr`, `this_ptr`
  is 8 bytes rather than 16 there, so `called_scope` and everything behind it
  were read off the wrong offset — `thread_call_closure` took a garbage class
  entry out of it and crashed in `ZEND_FETCH_OBJ_R`.
- `thread_copy_callable` handed `zend_create_closure` a `zval*` where the
  signature now takes a `zend_object*`, so the worker's closure carried a `$this`
  that was not an object.

## Measured

Against php-src `true-async` merged with `master`, release build:

| | tests | failed |
|---|---|---|
| before the merge | 1290 | 3 |
| after the merge, before this | 1289 | 40 |
| after the merge, with this | 1289 | 3 |

The three that remain are the ones this checkout always fails — the curl and io
tests whose `include` paths reach outside php-src because it is a symlink.

This is needed by the php-src merge and cannot land after it: a build carrying
one without the other crashes on any `$this`-bound closure sent to a thread.