### PR TITLE
release: 0.9.5

### DIFF
--- a/php_async.h
+++ b/php_async.h
@@ -50,8 +50,8 @@ PHP_ASYNC_API extern zend_class_entry *async_ce_fs_watcher;
 PHP_ASYNC_API extern zend_class_entry *async_ce_circuit_breaker_strategy;
 
 #define PHP_ASYNC_NAME "true_async"
-#define PHP_ASYNC_VERSION "0.9.3"
-#define PHP_ASYNC_NAME_VERSION "true async v0.9.3"
+#define PHP_ASYNC_VERSION "0.9.5"
+#define PHP_ASYNC_NAME_VERSION "true async v0.9.5"
 
 #define REACTOR_CHECK_INTERVAL (100 * 1000000) // ms in nanoseconds
 


### PR DESCRIPTION
Version macro only. It said 0.9.3 while the tags had reached v0.9.4, and `phpinfo()` reads it, so the reported version was a release behind.

The release itself carries the upstream $this follow-up (#268), the awaited vectored write with its failure report (ABI 0.26.0), the task and cancellation work, and the constant-expression literal handling.