### PR TITLE
ci(windows): drop the staging checkout before buildconf

### DIFF
--- a/.github/scripts/windows/test_task.bat
+++ b/.github/scripts/windows/test_task.bat
@@ -59,6 +59,18 @@ if %errorlevel% neq 0 (
 )
 
 echo.
+rem A build that silently dropped ext/async still runs the suite: every
+rem case skips on the missing module and the job reports success. Fail here
+rem instead, before the suite can turn an empty run into a green one.
+echo Verifying the async module is present in the binary...
+%PHP_BUILD_DIR%\php.exe -n -m | findstr /r /c:"^async$" >nul
+if %errorlevel% neq 0 (
+    echo ERROR: the async module is not built into php.exe!
+    %PHP_BUILD_DIR%\php.exe -n -m
+    exit /b 1
+)
+echo FOUND: async module
+echo.
 echo Running async extension tests...
 %PHP_BUILD_DIR%\php.exe run-tests.php --show-diff ext\async\tests
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -47,6 +47,18 @@ jobs:
         run: |
           xcopy /E /I /H /Y async\.github .github
 
+      - name: Drop the staging checkout from the php-src root
+        shell: cmd
+        run: |
+          rem buildconf's find_config_w32(".") scans every directory in the
+          rem php-src root for a config.w32, so the staging copy registers as
+          rem a second module next to ext/async. When the two directory names
+          rem differ, ARG_ENABLE('async', ..., 'no') is registered twice and
+          rem the duplicate -- never matched on the command line -- resets
+          rem PHP_ASYNC back to its 'no' default after --enable-async was
+          rem accepted, and the extension is silently left out of the build.
+          rmdir /s /q async
+
       - name: Setup LibUV
         shell: powershell
         run: |

--- a/.github/workflows/debug-windows-crash.yml
+++ b/.github/workflows/debug-windows-crash.yml
@@ -74,6 +74,18 @@ jobs:
         run: |
           xcopy /E /I /H /Y async\.github .github
 
+      - name: Drop the staging checkout from the php-src root
+        shell: cmd
+        run: |
+          rem buildconf's find_config_w32(".") scans every directory in the
+          rem php-src root for a config.w32, so the staging copy registers as
+          rem a second module next to ext/async. When the two directory names
+          rem differ, ARG_ENABLE('async', ..., 'no') is registered twice and
+          rem the duplicate -- never matched on the command line -- resets
+          rem PHP_ASYNC back to its 'no' default after --enable-async was
+          rem accepted, and the extension is silently left out of the build.
+          rmdir /s /q async
+
       - name: Setup LibUV
         shell: powershell
         run: |


### PR DESCRIPTION
Closes #270.

`buildconf.js:find_config_w32(".")` scans every directory in the php-src
root for a `config.w32`, not just TSRM and Zend. The checkout staged next
to `ext/` therefore registers as a module of its own.

In this repository's own job the staging directory is named `async`, so it
collides by name with `ext/async`, and the log reads
`Skipping ext/async -- already have a module with that name`: the build
compiles the staging copy and `ext/async` is ignored.

Where the names differ — `true-async/server` stages into `async-src` and
`http-server-src` — there is no collision, `ARG_ENABLE('async', …, 'no')`
is registered twice, and the second entry is never matched on the command
line. `conf_process_args` accepts `--enable-async` on the first entry and
then, in the loop that applies defaults to unseen arguments, assigns
`PHP_ASYNC = "no"` from the duplicate. The extension drops out of the
build, configure reports nothing, and the suite skips all 491 cases and
exits green.

That is what `--enable-snapshot-build` was papering over: the snapshot
path rewrites every unseen `'no'` default to `yes,shared`, so the
duplicate was flipped back on. The flag is not required to build an
out-of-tree extension — a clean root is.

Two changes:

- remove the staging checkout before `buildconf.bat` runs, in both the
  build and the crash-debug workflow;
- fail `test_task.bat` when `php -m` does not list `async`, so a build
  that lost the extension can no longer report a green empty run.
