### PR TITLE
ci(windows): check for the module under its real name

### DIFF
--- a/.github/scripts/windows/test_task.bat
+++ b/.github/scripts/windows/test_task.bat
@@ -62,14 +62,14 @@ echo.
 rem A build that silently dropped ext/async still runs the suite: every
 rem case skips on the missing module and the job reports success. Fail here
 rem instead, before the suite can turn an empty run into a green one.
-echo Verifying the async module is present in the binary...
-%PHP_BUILD_DIR%\php.exe -n -m | findstr /r /c:"^async$" >nul
+echo Verifying the true_async module is present in the binary...
+%PHP_BUILD_DIR%\php.exe -n -m | findstr /r /c:"^true_async$" >nul
 if %errorlevel% neq 0 (
-    echo ERROR: the async module is not built into php.exe!
+    echo ERROR: the true_async module is not built into php.exe!
     %PHP_BUILD_DIR%\php.exe -n -m
     exit /b 1
 )
-echo FOUND: async module
+echo FOUND: true_async module
 echo.
 echo Running async extension tests...
 %PHP_BUILD_DIR%\php.exe run-tests.php --show-diff ext\async\tests


### PR DESCRIPTION
Follow-up to #271.

`php -m` prints the extension as `true_async` — `PHP_ASYNC_NAME` in
`php_async.h:52`, used for `async_module_entry` — while the guard looked
for `async`. Run 32754370884 shows the effect: the build itself is now
correct (`| async | static |` in the table, and the
`Skipping ext/async -- already have a module with that name` line is
gone), but the test step rejected it.
