### PR TITLE
ci(windows): match the module line without an end anchor

### DIFF
--- a/.github/scripts/windows/test_task.bat
+++ b/.github/scripts/windows/test_task.bat
@@ -63,7 +63,7 @@ rem A build that silently dropped ext/async still runs the suite: every
 rem case skips on the missing module and the job reports success. Fail here
 rem instead, before the suite can turn an empty run into a green one.
 echo Verifying the true_async module is present in the binary...
-%PHP_BUILD_DIR%\php.exe -n -m | findstr /r /c:"^true_async$" >nul
+%PHP_BUILD_DIR%\php.exe -n -m | findstr /b /l /c:"true_async" >nul
 if %errorlevel% neq 0 (
     echo ERROR: the true_async module is not built into php.exe!
     %PHP_BUILD_DIR%\php.exe -n -m


### PR DESCRIPTION
Follow-up to #272.

`findstr` does not strip the carriage return from piped input, so `$` in
`"^true_async$"` cannot match a line ending in CRLF — which is what
`php -m` produces. Run 32758012450 printed `true_async` in the very
module list it then rejected.

Checked locally in a batch file: `findstr /r /c:"^true_async$"` exits 1
on that input, `findstr /b /l /c:"true_async"` exits 0.
