### PR TITLE
Stop asserting how far the upload got before the close

### DIFF
--- a/tests/curl/071-upload_stream_closed_mid_read.phpt
+++ b/tests/curl/071-upload_stream_closed_mid_read.phpt
@@ -40,7 +40,13 @@ curl_setopt($ch, CURLOPT_WRITEFUNCTION, static fn ($resource, $data) => strlen($
 /* The throttle spreads the upload over several seconds, so the close below falls
  * between two of curl's reads. With no read in flight the reactor holds no pin of
  * its own on the stream's IO, which is the state the subscription has to survive
- * on its own. */
+ * on its own.
+ *
+ * How far the upload gets before the close is not asserted: a runner whose socket
+ * buffer swallows the whole body reports the transfer done before the closing
+ * coroutine has a turn, which happens on macOS and FreeBSD. What the test holds to
+ * is that the process survives the close and both coroutines return -- before the
+ * php-src change this is a heap-use-after-free under ASAN. */
 curl_setopt($ch, CURLOPT_MAX_SEND_SPEED_LARGE, 65536);
 
 $uploading = false;
@@ -94,8 +100,6 @@ echo "End\n";
 ?>
 --EXPECTF--
 Start
-
-Warning: fclose(): CURLOPT_INFILE resource has gone away, resetting to default in %s on line %d
-transfer: aborted
+%Atransfer: %s
 stream closed
 End


### PR DESCRIPTION
Fixes the macOS and FreeBSD failures on main from #296.

Both runners swallow the whole body into the socket buffer and report the transfer done before the closing coroutine has a turn, so the test read `transfer: completed` where it demanded `aborted`, and the `CURLOPT_INFILE resource has gone away` warning never came. Linux, Alpine and Windows were green.

How far the upload gets is not what the test is for. It holds that the process survives a close under a parked read and that both coroutines return. That is still red before the php-src fix: measured again on this exact shape with the reference removed from `curl_async_read_cb` and `curl_async_read_dispatch` and the ASAN build relinked — 1 failed, and green with the reference back.

`ext/async/tests/curl` under ASAN — 68 passed, 0 failed.